### PR TITLE
#507 Implement `dispatchOnNextUpdate` for ActionDispatcher

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,11 @@
 /** @type {import('eslint').Linter.Config} */
-const year = new Date().getFullYear();
 module.exports = {
     extends: '@eclipse-glsp',
     parserOptions: {
         tsconfigRootDir: __dirname,
         project: 'tsconfig.json'
     },
-    plugins: ['chai-friendly'],
     rules: {
-        'no-shadow': 'off',
-        'brace-style': 'off',
-        '@typescript-eslint/no-this-alias': 'off',
-        // chai friendly
-        'no-unused-expressions': 0,
-        'chai-friendly/no-unused-expressions': 2
+        'no-shadow': 'off'
     }
 };

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,8 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/mocharc",
-  "require": ["ts-node/register", "reflect-metadata/Reflect"],
-  "reporter": "spec",
-  "color": true,
-  "watch-files": ["*.ts", "*.tsx"],
-  "timeout": 2000
+  "extends": "@eclipse-glsp/mocha-config"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,12 +40,22 @@
       "port": 9229
     },
     {
-      "name": "Debug workflow example GLSP Server",
-      "program": "${workspaceFolder}/examples/workflow-server/lib/index.js",
+      "type": "node",
       "request": "launch",
-      "skipFiles": ["<node_internals>/**"],
-      "console": "integratedTerminal",
-      "type": "pwa-node"
+      "name": "Debug Workflow Example Server",
+      "program": "${workspaceFolder}/examples/workflow-server/lib/index.js",
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceRoot}/node_modules/@eclipse-glsp/*/lib/**/*.js",
+        "${workspaceRoot}/node_modules/@eclipse-glsp-examples/*/lib/**/*.js",
+        "${workspaceRoot}/packages/*/lib/**/*.js"
+      ],
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "outputCapture": "std"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Eclipse GLSP Server Node Changelog
+
+## v0.10.0- Upcoming
+
+Inception of the Node GLSP Server.
+This project provides the Node based server component for the Eclipse Graphical Language Platform (GLSP).
+The implementation of this server is aligned with the default Java based [GLSP Server](https://github.com/eclipse-glsp/glsp-server).
+The initial initial implementation was contributed on behalf of STMicroelectronics.

--- a/examples/workflow-server/package.json
+++ b/examples/workflow-server/package.json
@@ -40,9 +40,6 @@
     "@eclipse-glsp/server-node": "0.9.0"
   },
   "devDependencies": {
-    "@types/node": "12.x",
-    "reflect-metadata": "^0.1.13",
-    "ts-node": "^10.4.0",
     "typescript": "^3.9.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,22 +19,11 @@
     "upgrade:next": "yarn upgrade -p \"@eclipse-glsp.*\" --next ",
     "start": "yarn --cwd examples/workflow-server start:server"
   },
-  "resolutions": {
-    "**/@eclipse-glsp/protocol": "0.9.0-next.e0116720"
-  },
   "devDependencies": {
     "@eclipse-glsp/config": "next",
-    "eslint-plugin-chai-friendly": "^0.7.2",
+    "@types/node": "12.x",
     "lerna": "^4.0.0",
-    "typescript": "^3.9.2",
-    "mocha-jenkins-reporter": "^0.4.7",
-    "mocha": "^9.1.3",
-    "chai": "^4.3.4",
-    "sinon": "^12.0.1",
-    "ts-node": "^10.4.0",
-    "@types/chai": "^4.2.22",
-    "@types/mocha": "^9.0.0",
-    "@types/sinon": "^10.0.6"
+    "typescript": "^3.9.2"
   },
   "workspaces": [
     "packages/*",

--- a/packages/server-node/package.json
+++ b/packages/server-node/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
-    "@types/node": "12.x",
     "reflect-metadata": "^0.1.13",
     "typescript": "^3.9.2"
   },

--- a/packages/server-node/src/operations/create-operation-handler.ts
+++ b/packages/server-node/src/operations/create-operation-handler.ts
@@ -21,6 +21,7 @@ import {
     CreateOperation,
     Operation,
     Point,
+    SelectAction,
     TriggerEdgeCreationAction,
     TriggerElementCreationAction,
     TriggerNodeCreationAction
@@ -84,8 +85,8 @@ export abstract class CreateNodeOperationHandler extends CreateOperationHandler 
         if (element) {
             container.children.push(element);
             element.parent = container;
+            this.actionDispatcher.dispatchAfterNextUpdate(new SelectAction(), new SelectAction([element.id]));
         }
-        // TODO: Dispatch Select Action after next update
     }
 
     getContainer(operation: CreateNodeOperation): GModelElement | undefined {

--- a/packages/server-node/src/test/mock-util.ts
+++ b/packages/server-node/src/test/mock-util.ts
@@ -104,6 +104,10 @@ export class StubCreateEdgeOperationHandler extends CreateEdgeOperationHandler {
 }
 
 export class StubActionDispatcher implements ActionDispatcher {
+    dispatchAfterNextUpdate(...actions: MaybeArray<Action[]>): void {
+        // NO-OP
+    }
+
     dispatch(action: Action): Promise<void> {
         return Promise.resolve();
     }


### PR DESCRIPTION
- Implement `dispatchOnNextUpdate` for ActionDispatcher 
- Use  the new API in the `CreateOperationHandler` to automatically select newly created nodes.

Also:
- Consume new @eclipse-glsp/mocha-config package and remove redundant devdependencies
- Update debug config for workflow example
- Add missing CHANGELOG.md file

Contributed on behalf of STMicroelectronics
Closes eclipse-glsp/glsp/issues/507