### PR TITLE
#507 Fix edge deletion for workflow example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,8 @@
       "outFiles": [
         "${workspaceRoot}/node_modules/@eclipse-glsp/*/lib/**/*.js",
         "${workspaceRoot}/node_modules/@eclipse-glsp-examples/*/lib/**/*.js",
-        "${workspaceRoot}/packages/*/lib/**/*.js"
+        "${workspaceRoot}/packages/*/lib/**/*.js",
+        "${workspaceRoot}/examples/*/lib/**/*.js"
       ],
       "smartStep": true,
       "internalConsoleOptions": "openOnSessionStart",

--- a/packages/server-node/src/features/model/gmodel-index.ts
+++ b/packages/server-node/src/features/model/gmodel-index.ts
@@ -50,7 +50,13 @@ export class GModelIndex {
         const typeSet = this.typeToElements.get(element.type) ?? [];
         typeSet.push(element);
         this.typeToElements.set(element.type, typeSet);
-        (element.children ?? []).forEach(child => this.doIndex(child));
+        (element.children ?? []).forEach(child => {
+            this.doIndex(child);
+            // Double check wether the parent reference of the child is set correctly
+            if (!child.parent) {
+                child.parent = element;
+            }
+        });
     }
 
     find(elementId: string, predicate?: (test: GModelElement) => boolean): GModelElement | undefined {


### PR DESCRIPTION
Update `GModelIndex` to set missing parent references during indexing. This ensures that deletion
of newly created elements works as expected.
Also update the implementaion of `DeleteOperationHandler` to use a `Logger` instance instead of console.log.

Fixes eclipse-glsp/glsp/issues/517