### PR TITLE
#620 Introduce explicit binding methods for diagram module

### DIFF
--- a/examples/workflow-server/src/workflow-diagram-module.ts
+++ b/examples/workflow-server/src/workflow-diagram-module.ts
@@ -14,25 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    ClassMultiBinding,
     CommandPaletteActionProvider,
     ContextMenuItemProvider,
-    DefaultToolPaletteItemProvider,
     DiagramConfiguration,
     GLSPServer,
     GModelDiagramModule,
     InstanceMultiBinding,
-    JsonRpcGLSPServer,
     LabelEditValidator,
     ModelValidator,
+    MultiBinding,
     NavigationTargetProvider,
     NavigationTargetResolver,
     OperationHandlerConstructor,
     PopupModelFactory,
-    ServerModule,
-    ToolPaletteItemProvider
+    ServerModule
 } from '@eclipse-glsp/server-node';
-import { injectable, interfaces } from 'inversify';
+import { BindingTarget } from '@eclipse-glsp/server-node/lib/di/binding-target';
+import { injectable } from 'inversify';
 import { CreateAutomatedTaskHandler } from './handler/create-automated-task-handler';
 import { CreateCategoryHandler } from './handler/create-category-handler';
 import { CreateDecisionNodeHandler } from './handler/create-decision-node-handler';
@@ -56,11 +54,8 @@ import { WorkflowPopupFactory } from './workflow-popup-factory';
 
 @injectable()
 export class WorkflowServerModule extends ServerModule {
-    override configure(bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind): void {
-        super.configure(bind, unbind, isBound, rebind);
-        bind(WorkflowGLSPServer).toSelf().inSingletonScope();
-        rebind(GLSPServer).toService(WorkflowGLSPServer);
-        rebind(JsonRpcGLSPServer).toService(WorkflowGLSPServer);
+    protected override bindGLSPServer(): BindingTarget<GLSPServer> {
+        return WorkflowGLSPServer;
     }
 }
 
@@ -68,23 +63,6 @@ export class WorkflowServerModule extends ServerModule {
 export class WorkflowDiagramModule extends GModelDiagramModule {
     get diagramType(): string {
         return 'workflow-diagram';
-    }
-
-    protected override configure(
-        bind: interfaces.Bind,
-        unbind: interfaces.Unbind,
-        isBound: interfaces.IsBound,
-        rebind: interfaces.Rebind
-    ): void {
-        super.configure(bind, unbind, isBound, rebind);
-        bind(DiagramConfiguration).to(WorkflowDiagramConfiguration).inSingletonScope();
-        bind(NavigationTargetResolver).to(WorkflowNavigationTargetResolver).inSingletonScope();
-        bind(ContextMenuItemProvider).to(WorkflowContextMenuItemProvider).inSingletonScope();
-        bind(CommandPaletteActionProvider).to(WorkflowCommandPaletteActionProvider).inSingletonScope();
-        bind(LabelEditValidator).to(WorkflowLabelEditValidator).inSingletonScope();
-        bind(PopupModelFactory).to(WorkflowPopupFactory).inSingletonScope();
-        bind(ModelValidator).to(WorkflowModelValidator).inSingletonScope();
-        bind(ToolPaletteItemProvider).to(DefaultToolPaletteItemProvider).inSingletonScope();
     }
 
     protected override configureOperationHandlers(binding: InstanceMultiBinding<OperationHandlerConstructor>): void {
@@ -100,7 +78,35 @@ export class WorkflowDiagramModule extends GModelDiagramModule {
         binding.add(CreateCategoryHandler);
     }
 
-    protected override configureNavigationTargetProviders(binding: ClassMultiBinding<NavigationTargetProvider>): void {
+    protected bindDiagramConfiguration(): BindingTarget<DiagramConfiguration> {
+        return WorkflowDiagramConfiguration;
+    }
+
+    protected override bindNavigationTargetResolver(): BindingTarget<NavigationTargetResolver> | undefined {
+        return WorkflowNavigationTargetResolver;
+    }
+
+    protected override bindContextMenuItemProvider(): BindingTarget<ContextMenuItemProvider> | undefined {
+        return WorkflowContextMenuItemProvider;
+    }
+
+    protected override bindCommandPaletteActionProvider(): BindingTarget<CommandPaletteActionProvider> | undefined {
+        return WorkflowCommandPaletteActionProvider;
+    }
+
+    protected override bindLabelEditValidator(): BindingTarget<LabelEditValidator> | undefined {
+        return WorkflowLabelEditValidator;
+    }
+
+    protected override bindPopupModelFactory(): BindingTarget<PopupModelFactory> | undefined {
+        return WorkflowPopupFactory;
+    }
+
+    protected override bindModelValidator(): BindingTarget<ModelValidator> | undefined {
+        return WorkflowModelValidator;
+    }
+
+    protected override configureNavigationTargetProviders(binding: MultiBinding<NavigationTargetProvider>): void {
         super.configureNavigationTargetProviders(binding);
         binding.add(NextNodeNavigationTargetProvider);
         binding.add(PreviousNodeNavigationTargetProvider);

--- a/packages/server-node/src/actions/action-dispatcher.spec.ts
+++ b/packages/server-node/src/actions/action-dispatcher.spec.ts
@@ -24,6 +24,7 @@ import { Logger } from '../utils/logger';
 import { DefaultActionDispatcher } from './action-dispatcher';
 import { ActionHandler } from './action-handler';
 import { ActionHandlerRegistry } from './action-handler-registry';
+import assert = require('assert');
 
 function waitSync(timeInMillis: number): void {
     const start = Date.now();
@@ -61,7 +62,7 @@ describe('test DefaultActionDispatcher', () => {
 
     describe('test with one-way actions (no response actions)', () => {
         it('dispatch- unhandled action', async () => {
-            expect(actionDispatcher.dispatch({ kind: 'unhandled' })).to.throw;
+            assert.rejects(actionDispatcher.dispatch({ kind: 'unhandled' }));
         });
 
         it('dispatch - one action', async () => {

--- a/packages/server-node/src/di/binding-target.spec.ts
+++ b/packages/server-node/src/di/binding-target.spec.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { expect } from 'chai';
+import { Container, ContainerModule, interfaces } from 'inversify';
+import * as sinon from 'sinon';
+import { applyBindingTarget } from './binding-target';
+// Simple no op classes to construct inversify binding syntaxes.
+class Target {}
+
+class SubTarget extends Target {}
+
+describe('BindingTarget', () => {
+    describe('bindTarget()', () => {
+        // Setup nested spies for the fluent inversify binding API
+        let context: {
+            bind: sinon.SinonStub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], interfaces.BindingToSyntax<any>>;
+            isBound: sinon.SinonStub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], boolean>;
+        };
+        let toSyntax: sinon.SinonStubbedInstance<interfaces.BindingToSyntax<any>>;
+        let whenOnSyntax: sinon.SinonStubbedInstance<interfaces.BindingWhenOnSyntax<any>>;
+
+        const setupStubs = (): {
+            context: {
+                bind: sinon.SinonStub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], interfaces.BindingToSyntax<any>>;
+                isBound: sinon.SinonStub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], boolean>;
+            };
+            toSyntax: sinon.SinonStubbedInstance<interfaces.BindingToSyntax<any>>;
+            inWhenOnSyntax: sinon.SinonStubbedInstance<interfaces.BindingInWhenOnSyntax<any>>;
+            whenOnSyntax: sinon.SinonStubbedInstance<interfaces.BindingWhenOnSyntax<any>>;
+        } => {
+            const container = new Container();
+            const bind = sinon.stub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], interfaces.BindingToSyntax<any>>();
+            const isBound = sinon.stub<[serviceIdentifier: interfaces.ServiceIdentifier<any>], boolean>();
+
+            let toSyntax: sinon.SinonStubbedInstance<interfaces.BindingToSyntax<any>> = {} as any;
+            let inWhenOnSyntax: sinon.SinonStubbedInstance<interfaces.BindingInWhenOnSyntax<any>> = {} as any;
+            container.load(
+                new ContainerModule(_bind => {
+                    const toStub = _bind('StubMe');
+                    inWhenOnSyntax = sinon.stub(toStub.to(Target));
+                    whenOnSyntax = sinon.stub(toStub.toConstantValue(''));
+                    toSyntax = sinon.stub(toStub);
+
+                    bind.returns(toSyntax);
+                    toSyntax.to.returns(inWhenOnSyntax);
+                    toSyntax.toSelf.returns(inWhenOnSyntax);
+                    toSyntax.toDynamicValue.returns(inWhenOnSyntax);
+                    toSyntax.toService.returns();
+                })
+            );
+
+            return {
+                context: { bind, isBound },
+                toSyntax,
+                inWhenOnSyntax,
+                whenOnSyntax
+            };
+        };
+
+        beforeEach(() => {
+            const stubs = setupStubs();
+            context = stubs.context;
+            toSyntax = stubs.toSyntax;
+            whenOnSyntax = stubs.whenOnSyntax;
+        });
+
+        describe('Bind to constructor', () => {
+            it('Should bind the service identifier `to` the given target with no scope', () => {
+                applyBindingTarget(context, Target, SubTarget);
+                expect(toSyntax.to.calledOnceWith(SubTarget)).to.be.true;
+            });
+
+            it('Should bind the service identifier `toSelf` with no scope', () => {
+                applyBindingTarget(context, Target, Target);
+                expect(toSyntax.toSelf.calledOnce).to.be.true;
+            });
+        });
+
+        describe('Bind to service', () => {
+            it('Should bind the service identifier `service` using the given target service with no scope', () => {
+                context.isBound.returns(true);
+                applyBindingTarget(context, Target, { service: SubTarget });
+                expect(toSyntax.toService.calledOnceWith(SubTarget)).to.be.true;
+            });
+            it('Should throw an error because the given target service is not bound', () => {
+                context.isBound.returns(false);
+                expect(() => applyBindingTarget(context, Target, { service: SubTarget })).to.throw();
+            });
+            it('The return syntax should be no op and invocation of a syntax function should throw an error', () => {
+                context.isBound.returns(true);
+                const syntax = applyBindingTarget(context, Target, { service: SubTarget });
+                expect(() => {
+                    syntax.inSingletonScope();
+                }).to.throw(
+                    `${Target.toString()} has been bound to 'service'.` +
+                        "Using 'in','when' or 'on' bindings after" +
+                        "a 'toService' binding is not possible."
+                );
+            });
+        });
+
+        describe('Bind to constant value', () => {
+            it('Should bind the service identifier `toConstantValue` using the given target with no scope', () => {
+                const subTarget = new SubTarget();
+                applyBindingTarget(context, Target, { constantValue: subTarget });
+                expect(toSyntax.toConstantValue.calledOnceWith(subTarget)).to.be.true;
+            });
+            it("The return syntax's in functions should be no op and invocation should log a warning", () => {
+                const spy = sinon.spy(console, 'warn');
+                const subTarget = new SubTarget();
+                const syntax = applyBindingTarget(context, Target, { constantValue: subTarget });
+                syntax.inSingletonScope();
+                expect(
+                    spy.calledWith(
+                        `${Target.toString()} has been bound to 'constantValue'. Binding in Singleton scope has no effect.` +
+                            'Constant value bindings are effectively Singleton bindings.'
+                    )
+                ).to.be.true;
+            });
+        });
+
+        describe('Bind to dynamic value', () => {
+            it('Should bind the service identifier `toDynamicValue` using the given factory function with no scope', () => {
+                applyBindingTarget(context, Target, { dynamicValue: context => new SubTarget() });
+                expect(toSyntax.toDynamicValue.calledOnce);
+            });
+        });
+    });
+});

--- a/packages/server-node/src/di/binding-target.ts
+++ b/packages/server-node/src/di/binding-target.ts
@@ -1,0 +1,165 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { AnyObject, Constructor } from '@eclipse-glsp/protocol';
+import { interfaces } from 'inversify';
+/**
+ * Collection of utility types and functions to enable flexible service binding with dedicated
+ * binding methods in the GLSP DI modules
+ */
+
+/**
+ * Binds the given service identifier to the given {@link BindingTarget}. If the service identifier is
+ * a {@link Constructor} and the target is the same constructor the service identifier will be bound to itself.
+ * @param bind The inversify bind function (typically provided from a GLSP DI module)
+ * @param serviceIdentifier The service identifier that should be bound.
+ * @param target The binding target.
+ * @returns The corresponding {@link interfaces.BindingInWhenOnSyntax}.
+ */
+export function applyBindingTarget<T>(
+    context: { bind: interfaces.Bind; isBound: interfaces.IsBound },
+    serviceIdentifier: interfaces.ServiceIdentifier<T>,
+    target: BindingTarget<T>
+): interfaces.BindingInWhenOnSyntax<T> {
+    if (isConstructor(target)) {
+        // If service identifier and target are the same constructor => self binding
+        return serviceIdentifier === target //
+            ? context.bind(serviceIdentifier).toSelf()
+            : context.bind(serviceIdentifier).to(target);
+    } else if (ServiceTarget.is(target)) {
+        if (!context.isBound(target.service)) {
+            throw new Error(`The target service ${target.service.toString()} is not bound!. Cannot apply target binding`);
+        }
+        context.bind(serviceIdentifier).toService(target.service);
+        return NoOPSyntax.serviceSyntax(serviceIdentifier);
+    } else if (ConstantValueTarget.is(target)) {
+        const whenOnSyntax = context.bind(serviceIdentifier).toConstantValue(target.constantValue);
+        return NoOPSyntax.constantValueSyntax(serviceIdentifier, whenOnSyntax);
+    } else {
+        return context.bind(serviceIdentifier).toDynamicValue(_context => target.dynamicValue(_context));
+    }
+}
+
+export function applyOptionalBindingTarget<T>(
+    context: { bind: interfaces.Bind; isBound: interfaces.IsBound },
+    serviceIdentifier: interfaces.ServiceIdentifier<T>,
+    target?: BindingTarget<T>
+): interfaces.BindingInWhenOnSyntax<T> | undefined {
+    if (target) {
+        return applyBindingTarget(context, serviceIdentifier, target);
+    }
+    return undefined;
+}
+
+/**
+ * The different types of binding targets that can be returned by a dedicated binding method.
+ */
+export type BindingTarget<T> = Constructor<T> | DynamicValueTarget<T> | ConstantValueTarget<T> | ServiceTarget<T>;
+
+/**
+ * Binding target for service identifiers that should be bound `toConstantValue`.
+ */
+export interface ConstantValueTarget<T> {
+    constantValue: T;
+}
+
+export namespace ConstantValueTarget {
+    export function is(object: any): object is ConstantValueTarget<unknown> {
+        return AnyObject.is(object) && 'constantValue' in object;
+    }
+}
+
+/**
+ * Binding target for service identifiers that should be bound `toService`.
+ */
+export interface ServiceTarget<T> {
+    service: interfaces.ServiceIdentifier<T>;
+}
+
+export namespace ServiceTarget {
+    export function is(object: any): object is ServiceTarget<unknown> {
+        return AnyObject.is(object) && 'service' in object;
+    }
+}
+
+/**
+ * Binding target for service identifiers that should be bound `toDynamicValue`.
+ */
+export interface DynamicValueTarget<T> {
+    dynamicValue(context: interfaces.Context): T;
+}
+
+/**
+ * No-op binding syntax definitions for `constantValue` and `toService` bindings.
+ * Using this no-op syntaxes allows the {@link applyBindingTarget} function to return a {@interfaces.BindingInWhenOnSyntax}
+ * independently of the actual {@link BindingTarget}.
+ */
+namespace NoOPSyntax {
+    export function constantValueSyntax(
+        serviceIdentifier: interfaces.ServiceIdentifier<any>,
+        syntax: interfaces.BindingWhenOnSyntax<any>
+    ): interfaces.BindingInWhenOnSyntax<any> {
+        const noOpReturn = (scope: string): interfaces.BindingWhenOnSyntax<any> => {
+            console.warn(
+                `${serviceIdentifier.toString()} has been bound to 'constantValue'. Binding in ${scope} scope has no effect.` +
+                    'Constant value bindings are effectively Singleton bindings.'
+            );
+            return syntax;
+        };
+        return {
+            ...syntax,
+            inSingletonScope: () => noOpReturn('Singleton'),
+            inRequestScope: () => noOpReturn('Request'),
+            inTransientScope: () => noOpReturn('Transient')
+        };
+    }
+
+    export function serviceSyntax(serviceIdentifier: interfaces.ServiceIdentifier<any>): interfaces.BindingInWhenOnSyntax<any> {
+        const noOpReturn = (): interfaces.BindingInWhenOnSyntax<any> => {
+            const errorMsg =
+                `${serviceIdentifier.toString()} has been bound to 'service'.` +
+                "Using 'in','when' or 'on' bindings after" +
+                "a 'toService' binding is not possible.";
+            const error = new Error(errorMsg);
+            error.name = 'NoOpInvocation';
+            throw error;
+        };
+        return {
+            onActivation: noOpReturn,
+            when: noOpReturn,
+            whenAnyAncestorIs: noOpReturn,
+            whenAnyAncestorMatches: noOpReturn,
+            whenAnyAncestorNamed: noOpReturn,
+            whenAnyAncestorTagged: noOpReturn,
+            whenInjectedInto: noOpReturn,
+            whenNoAncestorIs: noOpReturn,
+            whenNoAncestorMatches: noOpReturn,
+            whenNoAncestorNamed: noOpReturn,
+            whenNoAncestorTagged: noOpReturn,
+            whenParentNamed: noOpReturn,
+            whenParentTagged: noOpReturn,
+            whenTargetIsDefault: noOpReturn,
+            whenTargetNamed: noOpReturn,
+            whenTargetTagged: noOpReturn,
+            inRequestScope: noOpReturn,
+            inSingletonScope: noOpReturn,
+            inTransientScope: noOpReturn
+        };
+    }
+}
+
+export function isConstructor(object: any): object is Constructor<unknown> {
+    return typeof object === 'function' && !!object.prototype && !!(object.prototype as any).constructor;
+}

--- a/packages/server-node/src/di/glsp-module.ts
+++ b/packages/server-node/src/di/glsp-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { ContainerModule, injectable, interfaces } from 'inversify';
-import { MultiBinding } from './multi-binding';
+import { AbstractMultiBinding } from './multi-binding';
 
 /**
  * A wrapper interface to get access to the binding related functions
@@ -59,7 +59,7 @@ export abstract class GLSPModule extends ContainerModule {
      * @param binding      The multi binding configuration object
      * @param configurator The consumer that should be used to configure the given {@link MultiBinding}
      */
-    protected configureMultiBinding<T>(binding: MultiBinding<T>, configurator: (binding: MultiBinding<T>) => void): void {
+    protected configureMultiBinding<T>(binding: AbstractMultiBinding<T>, configurator: (binding: AbstractMultiBinding<T>) => void): void {
         configurator(binding);
         binding.applyBindings(this.context);
     }

--- a/packages/server-node/src/di/multi-bindings.spec.ts
+++ b/packages/server-node/src/di/multi-bindings.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { expect } from 'chai';
 import { Container, ContainerModule, injectable } from 'inversify';
-import { ClassMultiBinding, InstanceMultiBinding } from './multi-binding';
+import { InstanceMultiBinding, MultiBinding } from './multi-binding';
 
 @injectable()
 class TestClass {}
@@ -31,7 +31,7 @@ class TestClass3 extends TestClass {}
 
 describe('test implementations of MultiBinding', () => {
     describe('test basic functionaly (ClassMultiBinding) ', () => {
-        const binding = new ClassMultiBinding('TestClass');
+        const binding = new MultiBinding('TestClass');
         it('add - new binding', () => {
             binding.add(TestClass1);
             expect(binding.contains(TestClass1)).true;
@@ -97,7 +97,7 @@ describe('test implementations of MultiBinding', () => {
             const testContainer = new Container();
             const testModule = new ContainerModule((bind, unbind, isBound, rebind) => {
                 const context = { bind, unbind, isBound, rebind };
-                const binding = new ClassMultiBinding('TestClass');
+                const binding = new MultiBinding('TestClass');
                 binding.addAll([TestClass1, TestClass2, TestClass3]);
                 binding.applyBindings(context);
             });

--- a/packages/server-node/src/features/directediting/apply-label-edit-operation-handler.spec.ts
+++ b/packages/server-node/src/features/directediting/apply-label-edit-operation-handler.spec.ts
@@ -20,6 +20,7 @@ import * as sinon from 'sinon';
 import { GModelState } from '../../base-impl/gmodel-state';
 import { GModelIndex } from '../model/gmodel-index';
 import { ApplyLabelEditOperationHandler } from './apply-label-edit-operation-handler';
+import assert = require('assert');
 
 describe('Test ApplyLabelEditOperationHandler', () => {
     const label = new GLabel();
@@ -30,7 +31,9 @@ describe('Test ApplyLabelEditOperationHandler', () => {
     Object.defineProperty(applyLabelEditOperationHandler, 'modelState', { value: modelState });
 
     it('text is changed after ApplyLabelEditOperation', async () => {
-        expect(applyLabelEditOperationHandler.execute(ApplyLabelEditOperation.create({ labelId: 'myId', text: 'test' }))).to.not.throw;
+        assert.doesNotThrow(() =>
+            applyLabelEditOperationHandler.execute(ApplyLabelEditOperation.create({ labelId: 'myId', text: 'test' }))
+        );
         expect(label.text).to.be.equal('test');
     });
 });

--- a/packages/server-node/src/launch/cli-parser.spec.ts
+++ b/packages/server-node/src/launch/cli-parser.spec.ts
@@ -13,10 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { expect } from 'chai';
 import * as path from 'path';
 import { LogLevel } from '../utils/logger';
 import { createCliParser, defaultLaunchOptions } from './cli-parser';
-import { expect } from 'chai';
 
 describe('test createCliParser', () => {
     const parser = createCliParser();
@@ -30,7 +30,7 @@ describe('test createCliParser', () => {
     });
 
     it('parse - invalid log dir', () => {
-        expect(() => parser.parse([...argv, '--logDir', 'invalid.Path'])).to.throw;
+        expect(() => parser.parse([...argv, '--logDir', 'invalid.Path'])).to.throw();
     });
 
     it('parse - valid log dir', () => {
@@ -40,7 +40,7 @@ describe('test createCliParser', () => {
     });
 
     it('parse - invalid logLevel', () => {
-        expect(() => parser.parse([...argv, '--logLevel', 'someRandomLevel'])).to.throw;
+        expect(() => parser.parse([...argv, '--logLevel', 'someRandomLevel'])).to.throw();
     });
 
     it('parse - valid logLevel', () => {

--- a/packages/server-node/src/launch/socket-cli-parser.spec.ts
+++ b/packages/server-node/src/launch/socket-cli-parser.spec.ts
@@ -13,9 +13,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { expect } from 'chai';
 import { LogLevel } from '../utils/logger';
 import { createSocketCliParser, defaultSocketLaunchOptions, SocketLaunchOptions } from './socket-cli-parser';
-import { expect } from 'chai';
 
 describe('test createCliParser', () => {
     const parser = createSocketCliParser();
@@ -29,11 +29,11 @@ describe('test createCliParser', () => {
     });
 
     it('parse - invalid port (below lower range)', () => {
-        expect(() => parser.parse([...argv, '--port', '-1'])).to.throw;
+        expect(() => parser.parse([...argv, '--port', '-1'])).to.throw();
     });
 
     it('parse - invalid port (below upper range)', () => {
-        expect(() => parser.parse([...argv, '--port', '65536'])).to.throw;
+        expect(() => parser.parse([...argv, '--port', '65536'])).to.throw();
     });
 
     it('parse - valid port', () => {

--- a/packages/server-node/src/protocol/glsp-server.spec.ts
+++ b/packages/server-node/src/protocol/glsp-server.spec.ts
@@ -24,6 +24,7 @@ import { Logger } from '../utils/logger';
 import { GLSPClientProxy, JsonRpcGLSPClientProxy } from './glsp-client-proxy';
 import { DefaultGLSPServer } from './glsp-server';
 import { GLSPServerListener } from './glsp-server-listener';
+import assert = require('assert');
 
 describe('test DefaultGLSPServer', () => {
     const container = new Container();
@@ -66,9 +67,9 @@ describe('test DefaultGLSPServer', () => {
     });
 
     it('Test calls before server initialization (should throw errors)', async () => {
-        expect(async () => glspServer.initializeClientSession({ clientSessionId: 'id', diagramType: 'type' })).to.throw;
-        expect(async () => glspServer.disposeClientSession({ clientSessionId: 'id' })).to.throw;
-        expect(async () => glspServer.process({ clientId: 'id', action: { kind: 'action' } })).to.throw;
+        assert.rejects(() => glspServer.initializeClientSession({ clientSessionId: 'id', diagramType: 'type' }));
+        assert.rejects(() => glspServer.disposeClientSession({ clientSessionId: 'id' }));
+        assert.throws(() => glspServer.process({ clientId: 'id', action: { kind: 'action' } }));
     });
 
     it('addListener - add existing listener', () => {
@@ -98,7 +99,7 @@ describe('test DefaultGLSPServer', () => {
 
     it('initialize - with wrong protocol version', async () => {
         const initializeParameters: InitializeParameters = { applicationId, protocolVersion: 'abc' };
-        await expect(async () => glspServer.initialize(initializeParameters)).to.throw;
+        assert.rejects(glspServer.initialize(initializeParameters));
     });
 
     it('initialize - with correct parameters', async () => {
@@ -121,7 +122,7 @@ describe('test DefaultGLSPServer', () => {
 
     it('initialize -  subsequent call with other parameters', async () => {
         const initializeParameters = { applicationId: 'someOtherApp', protocolVersion: 'AnotherProtocolVersion' };
-        await expect(async () => glspServer.initialize(initializeParameters)).to.throw;
+        await assert.rejects(() => glspServer.initialize(initializeParameters));
     });
 
     it('initialize client session', async () => {

--- a/packages/server-node/src/test/integration-test.spec.ts
+++ b/packages/server-node/src/test/integration-test.spec.ts
@@ -24,10 +24,11 @@ import {
     RequestModelAction
 } from '@eclipse-glsp/protocol';
 import { expect } from 'chai';
-import { Container, ContainerModule, injectable, interfaces } from 'inversify';
+import { Container, ContainerModule, injectable } from 'inversify';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { GModelDiagramModule } from '../base-impl/gmodel-diagram-module';
+import { BindingTarget } from '../di/binding-target';
 import { InstanceMultiBinding } from '../di/multi-binding';
 import { ServerModule } from '../di/server-module';
 import { InjectionContainer } from '../di/service-identifiers';
@@ -48,21 +49,14 @@ const clientId = 'session1';
 const sourceUri = path.resolve(__dirname, 'minimal.json');
 
 class TestDiagramModule extends GModelDiagramModule {
-    diagramType = diagramType;
-
-    protected override configure(
-        bind: interfaces.Bind,
-        unbind: interfaces.Unbind,
-        isBound: interfaces.IsBound,
-        rebind: interfaces.Rebind
-    ): void {
-        super.configure(bind, unbind, isBound, rebind);
-        bind(DiagramConfiguration).toConstantValue(
-            new (class extends mock.StubDiagramConfiguration {
+    protected bindDiagramConfiguration(): BindingTarget<DiagramConfiguration> {
+        return {
+            constantValue: new (class extends mock.StubDiagramConfiguration {
                 override typeMapping = getDefaultMapping();
             })()
-        );
+        };
     }
+    diagramType = diagramType;
 
     override configureOperationHandlers(binding: InstanceMultiBinding<OperationHandlerConstructor>): void {
         super.configureOperationHandlers(binding);
@@ -117,7 +111,7 @@ describe('Integration tests for a glsp server created by SocketServerLauncher', 
                     }
                 })
             })
-        ).to.throw;
+        ).to.throw();
     });
 
     it('initialize - should return valid initializeResult', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
 "@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.17.9.tgz#61b2ee7f32ea0454612def4fccdae0de232b73e3"
+  integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
@@ -96,9 +96,9 @@
   integrity sha512-GrIHVf41ZYfoHIs97JXukUAmTS6IHQ4n1MnIJcNILJ38lLoFb254QYWdpLybbtu8xmXMdqPOHlrJE1J6TrB5Ow==
 
 "@eclipse-glsp/protocol@next":
-  version "0.10.0-next.5043408.167"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.5043408.167.tgz#cd1f00bad31f06e001ccbcf23437edd92df40d07"
-  integrity sha512-GDbLtkoA6BpuCTHP+bZp9ePE9SCYChf7/EAOOW7kWxYSfNwoovQSn3hEIIowzpAGAh1wxLPNcp7B6u7HD2DBew==
+  version "0.10.0-next.b3a810f.172"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.10.0-next.b3a810f.172.tgz#ee4ee6d4211e0bbd61000782f1d5fbea2ce5298c"
+  integrity sha512-GRqaq9YIl3ewGj1h+DeS9+LJALS/0FFSwhYjmwYkEd1v0cLyBlNuZ1ymLyGw6ckG9PrpeK9TWwMw4jAjpMK4WA==
   dependencies:
     sprotty-protocol next
     uuid "7.0.3"
@@ -1019,9 +1019,9 @@
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@>=5":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz#7b698e0b9d12d93611f06ee143c30ced848e2840"
-  integrity sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -1072,9 +1072,9 @@
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/chai@^4.2.22":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
-  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
+  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
 
 "@types/fs-extra@^9.0.13":
   version "9.0.13"
@@ -1104,19 +1104,19 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/mocha@^9.0.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.0.tgz#baf17ab2cca3fcce2d322ebc30454bff487efad5"
-  integrity sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
+  integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
 "@types/node@*":
-  version "17.0.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
-  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
+  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
 
 "@types/node@12.x":
-  version "12.20.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
-  integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
+  version "12.20.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.48.tgz#55f70bd432b6515828c0298689776861b90ca4fa"
+  integrity sha512-4kxzqkrpwYtn6okJUcb2lfUu9ilnb3yhUOH6qX3nug8D2DupZ2drIkff2yJzYcNJVl3begnlcaBJ7tqiTTzjnQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1146,13 +1146,13 @@
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@typescript-eslint/eslint-plugin@^5.13.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.17.0.tgz#704eb4e75039000531255672bf1c85ee85cf1d67"
-  integrity sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz#022531a639640ff3faafaf251d1ce00a2ef000a1"
+  integrity sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/type-utils" "5.17.0"
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.20.0"
+    "@typescript-eslint/type-utils" "5.20.0"
+    "@typescript-eslint/utils" "5.20.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -1161,75 +1161,75 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@^5.0.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.17.0.tgz#303ba1d766d715c3225a31845b54941889e52f6c"
-  integrity sha512-U4sM5z0/ymSYqQT6I7lz8l0ZZ9zrya5VIwrwAP5WOJVabVtVsIpTMxPQe+D3qLyePT+VlETUTO2nA1+PufPx9Q==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.20.0.tgz#7ed593bed40424d9c4160f3f86c3f6f56d6c87af"
+  integrity sha512-w5qtx2Wr9x13Dp/3ic9iGOGmVXK5gMwyc8rwVgZU46K9WTjPZSyPvdER9Ycy+B5lNHvoz+z2muWhUvlTpQeu+g==
   dependencies:
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/utils" "5.20.0"
 
 "@typescript-eslint/parser@^5.13.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.17.0.tgz#7def77d5bcd8458d12d52909118cf3f0a45f89d5"
-  integrity sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.20.0.tgz#4991c4ee0344315c2afc2a62f156565f689c8d0b"
+  integrity sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/typescript-estree" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.20.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/typescript-estree" "5.20.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz#4cea7d0e0bc0e79eb60cad431c89120987c3f952"
-  integrity sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==
+"@typescript-eslint/scope-manager@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz#79c7fb8598d2942e45b3c881ced95319818c7980"
+  integrity sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
 
-"@typescript-eslint/type-utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.17.0.tgz#1c4549d68c89877662224aabb29fbbebf5fc9672"
-  integrity sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==
+"@typescript-eslint/type-utils@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz#151c21cbe9a378a34685735036e5ddfc00223be3"
+  integrity sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==
   dependencies:
-    "@typescript-eslint/utils" "5.17.0"
+    "@typescript-eslint/utils" "5.20.0"
     debug "^4.3.2"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.17.0.tgz#861ec9e669ffa2aa9b873dd4d28d9b1ce26d216f"
-  integrity sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==
+"@typescript-eslint/types@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.20.0.tgz#fa39c3c2aa786568302318f1cb51fcf64258c20c"
+  integrity sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==
 
-"@typescript-eslint/typescript-estree@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz#a7cba7dfc8f9cc2ac78c18584e684507df4f2488"
-  integrity sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==
+"@typescript-eslint/typescript-estree@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz#ab73686ab18c8781bbf249c9459a55dc9417d6b0"
+  integrity sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/visitor-keys" "5.17.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/visitor-keys" "5.20.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.17.0.tgz#549a9e1d491c6ccd3624bc3c1b098f5cfb45f306"
-  integrity sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==
+"@typescript-eslint/utils@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.20.0.tgz#b8e959ed11eca1b2d5414e12417fd94cae3517a5"
+  integrity sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.17.0"
-    "@typescript-eslint/types" "5.17.0"
-    "@typescript-eslint/typescript-estree" "5.17.0"
+    "@typescript-eslint/scope-manager" "5.20.0"
+    "@typescript-eslint/types" "5.20.0"
+    "@typescript-eslint/typescript-estree" "5.20.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz#52daae45c61b0211b4c81b53a71841911e479128"
-  integrity sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==
+"@typescript-eslint/visitor-keys@5.20.0":
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz#70236b5c6b67fbaf8b2f58bf3414b76c1e826c2a"
+  integrity sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==
   dependencies:
-    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/types" "5.20.0"
     eslint-visitor-keys "^3.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -1403,13 +1403,14 @@ array-union@^2.1.0:
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array.prototype.flat@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
-  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.19.0"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -1951,7 +1952,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2032,11 +2033,12 @@ defaults@^1.0.3:
     clone "^1.0.2"
 
 define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
-    object-keys "^1.0.12"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2069,9 +2071,9 @@ detect-indent@^6.0.0:
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 dezalgo@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
   dependencies:
     asap "^2.0.0"
     wrappy "1"
@@ -2183,10 +2185,10 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1:
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.2.tgz#8f7b696d8f15b167ae3640b4060670f3d054143f"
-  integrity sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==
+es-abstract@^1.19.1, es-abstract@^1.19.2:
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.5.tgz#a2cb01eb87f724e815b278b0dd0d00f36ca9a7f1"
+  integrity sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -2199,7 +2201,7 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     is-callable "^1.2.4"
     is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.1"
+    is-shared-array-buffer "^1.0.2"
     is-string "^1.0.7"
     is-weakref "^1.0.2"
     object-inspect "^1.12.0"
@@ -2208,6 +2210,13 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -2246,7 +2255,7 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-module-utils@^2.7.2:
+eslint-module-utils@^2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
   integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
@@ -2274,23 +2283,23 @@ eslint-plugin-header@^3.1.1:
   integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
 
 eslint-plugin-import@^2.25.4:
-  version "2.25.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
-  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flat "^1.2.5"
     debug "^2.6.9"
     doctrine "^2.1.0"
     eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.2"
+    eslint-module-utils "^2.7.3"
     has "^1.0.3"
-    is-core-module "^2.8.0"
+    is-core-module "^2.8.1"
     is-glob "^4.0.3"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     object.values "^1.1.5"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.12.0"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-no-null@^1.0.2:
   version "1.0.2"
@@ -2331,9 +2340,9 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.10.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.12.0.tgz#c7a5bd1cfa09079aae64c9076c07eada66a46e8e"
-  integrity sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.13.0.tgz#6fcea43b6811e655410f5626cfcf328016badcd7"
+  integrity sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==
   dependencies:
     "@eslint/eslintrc" "^1.2.1"
     "@humanwhocodes/config-array" "^0.9.2"
@@ -2487,9 +2496,9 @@ fastq@^1.6.0:
     reusify "^1.0.4"
 
 fecha@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
-  integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
 figures@^3.0.0:
   version "3.2.0"
@@ -2784,9 +2793,9 @@ globby@^11.0.2, globby@^11.0.4:
     slash "^3.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
-  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growl@1.10.5:
   version "1.10.5"
@@ -2824,9 +2833,9 @@ hard-rejection@^2.1.0:
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
 has-bigints@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
-  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2837,6 +2846,13 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
 
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
@@ -2903,9 +2919,9 @@ http-signature@~1.2.0:
     sshpk "^1.7.0"
 
 https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
     debug "4"
@@ -3097,10 +3113,10 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.5.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
-  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+is-core-module@^2.5.0, is-core-module@^2.8.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
+  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
   dependencies:
     has "^1.0.3"
 
@@ -3146,9 +3162,9 @@ is-negative-zero@^2.0.2:
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
-  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
   dependencies:
     has-tostringtag "^1.0.0"
 
@@ -3192,10 +3208,12 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-shared-array-buffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
-  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-ssh@^1.3.0:
   version "1.3.3"
@@ -3675,7 +3693,7 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -4110,7 +4128,7 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -4457,9 +4475,9 @@ prelude-ls@^1.2.1:
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^2.4.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
-  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4750,7 +4768,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0, resolve@^1.20.0:
+resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -4841,9 +4859,9 @@ semver@^6.0.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -4936,15 +4954,15 @@ socks-proxy-agent@^5.0.0:
     socks "^2.3.3"
 
 socks-proxy-agent@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz#e664e8f1aaf4e1fb3df945f09e3d94f911137f87"
-  integrity sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz#f6b5229cc0cbd6f2f202d9695f09d871e951c85e"
+  integrity sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==
   dependencies:
     agent-base "^6.0.2"
-    debug "^4.3.1"
-    socks "^2.6.1"
+    debug "^4.3.3"
+    socks "^2.6.2"
 
-socks@^2.3.3, socks@^2.6.1:
+socks@^2.3.3, socks@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
   integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
@@ -5017,19 +5035,19 @@ split@^1.0.0:
     through "2"
 
 sprotty-elk@next:
-  version "0.11.0-next.e898c14.30"
-  resolved "https://registry.yarnpkg.com/sprotty-elk/-/sprotty-elk-0.11.0-next.e898c14.30.tgz#6c341430e28e0e66f606bf1e35d8bdf2e8316f5a"
-  integrity sha512-dWxLL1reG3Y2hWmPpNBA+W1xcZKy/bG9S6NTNPBTZZblfnwcM8H/805kYp6aoePagKvqZfaycwjPIW68+vpqkw==
+  version "0.12.0-next.00a6590.0"
+  resolved "https://registry.yarnpkg.com/sprotty-elk/-/sprotty-elk-0.12.0-next.00a6590.0.tgz#dadceb1fd5487d3cfde09ca28e112fc8ed91015a"
+  integrity sha512-/mZNAZxFhU5OEBJn8/5rPW1KZNMsYJUupa/pM2GyP+wAruw4hyQR6lxATBkXgSyw1/J+Stgwd9y35OfKOHHofA==
   dependencies:
     elkjs "^0.7.1"
-    sprotty-protocol "0.11.0-next.e898c14.30+e898c14"
+    sprotty-protocol "0.12.0-next.00a6590.0"
   optionalDependencies:
     inversify "^5.0.1"
 
-sprotty-protocol@0.11.0-next.e898c14.30+e898c14, sprotty-protocol@next:
-  version "0.11.0-next.e898c14.30"
-  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.11.0-next.e898c14.30.tgz#19a860d9967d17ed0c5c79aa361a51836f901d23"
-  integrity sha512-Eop7azThw6GUWc9TH8tWtaOCaPcubIlwUcqm+nZ52r8leFUArmXRE9vqJ+MtlnKEhYcaR7EDFB0dkPMtqyy5BQ==
+sprotty-protocol@0.12.0-next.00a6590.0, sprotty-protocol@next:
+  version "0.12.0-next.00a6590.0"
+  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.12.0-next.00a6590.0.tgz#31d65d864a8c662f0621ed313b8315a72ca97689"
+  integrity sha512-qs41TNmkbxvZ5K6BSwrnBdVUIUlg10FAkNwzdDTtThax4R78cHHT54DlAcEFlF16pAvNBRLZ/I0Fyv8/zYY3cQ==
 
 sshpk@^1.7.0:
   version "1.17.0"
@@ -5326,7 +5344,7 @@ ts-node@^10.4.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tsconfig-paths@^3.12.0:
+tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
@@ -5342,9 +5360,9 @@ tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -5425,9 +5443,9 @@ typescript@~4.5.5:
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uglify-js@^3.1.4:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
-  integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
+  version "3.15.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.4.tgz#fa95c257e88f85614915b906204b9623d4fa340d"
+  integrity sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -5508,9 +5526,9 @@ uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache-lib@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
-  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -5629,9 +5647,9 @@ winston-transport@^4.5.0:
     triple-beam "^1.3.0"
 
 winston@^3.3.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.6.0.tgz#be32587a099a292b88c49fac6fa529d478d93fb6"
-  integrity sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.7.2.tgz#95b4eeddbec902b3db1424932ac634f887c400b1"
+  integrity sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==
   dependencies:
     "@dabh/diagnostics" "^2.0.2"
     async "^3.2.3"


### PR DESCRIPTION
Introduce the concept of `BindingTargets` which enables us to define bindings in the diagram and server modules in a more explicit way using dedicated submethods. (Similar to the pattern we currently use in the Java  GLSP Server).  Using `BindingTargets` allows us to move the specification of the target binding into a
submethod without limiting the power of inversify. Adopters can still chose whether they want to bind a service identifier to constructor, self, constant value or another service.

In addition, this change fixes a couple of issues in the test setup regarding error handling.

Fixes eclipse-glsp/glsp/issues/629