### PR TITLE
GH-631 Improve to service bindings in diagram module

### DIFF
--- a/examples/workflow-server/src/handler/create-activity-node-handler.ts
+++ b/examples/workflow-server/src/handler/create-activity-node-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { CreateNodeOperation, GNode, ModelState, Point } from '@eclipse-glsp/server-node';
+import { CreateNodeOperation, GNode, Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { ActivityNode, ActivityNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -22,10 +22,10 @@ import { CreateWorkflowNodeOperationHandler } from './create-workflow-node-opera
 @injectable()
 export abstract class CreateActivityNodeHandler extends CreateWorkflowNodeOperationHandler {
     createNode(operation: CreateNodeOperation, relativeLocation?: Point): GNode | undefined {
-        return this.builder(relativeLocation, this.modelState).build();
+        return this.builder(relativeLocation).build();
     }
 
-    protected builder(point: Point | undefined, modelState: ModelState): ActivityNodeBuilder {
+    protected builder(point: Point | undefined): ActivityNodeBuilder {
         return ActivityNode.builder()
             .position(point ?? Point.ORIGIN)
             .type(this.elementTypeIds[0])

--- a/examples/workflow-server/src/handler/create-automated-task-handler.ts
+++ b/examples/workflow-server/src/handler/create-automated-task-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelState, Point } from '@eclipse-glsp/server-node';
+import { Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { TaskNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -24,7 +24,7 @@ export class CreateAutomatedTaskHandler extends CreateTaskHandler {
     elementTypeIds = [ModelTypes.AUTOMATED_TASK];
     label = 'Automated Task';
 
-    protected override builder(point: Point | undefined, modelState: ModelState): TaskNodeBuilder {
-        return super.builder(point, modelState).addCssClass('automated');
+    protected override builder(point: Point | undefined): TaskNodeBuilder {
+        return super.builder(point).addCssClass('automated');
     }
 }

--- a/examples/workflow-server/src/handler/create-category-handler.ts
+++ b/examples/workflow-server/src/handler/create-category-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ArgsUtil, CreateNodeOperation, GNode, ModelState, Point } from '@eclipse-glsp/server-node';
+import { ArgsUtil, CreateNodeOperation, GNode, Point } from '@eclipse-glsp/server-node';
 import { Category, CategoryNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
 import { CreateWorkflowNodeOperationHandler } from './create-workflow-node-operation-handler';
@@ -23,10 +23,10 @@ export class CreateCategoryHandler extends CreateWorkflowNodeOperationHandler {
     label = 'Category';
 
     createNode(operation: CreateNodeOperation, relativeLocation?: Point): GNode | undefined {
-        return this.builder(relativeLocation, this.modelState).build();
+        return this.builder(relativeLocation).build();
     }
 
-    protected builder(point: Point | undefined, modelState: ModelState): CategoryNodeBuilder {
+    protected builder(point: Point | undefined): CategoryNodeBuilder {
         return Category.builder()
             .type(this.elementTypeIds[0])
             .position(point ?? Point.ORIGIN)

--- a/examples/workflow-server/src/handler/create-decision-node-handler.ts
+++ b/examples/workflow-server/src/handler/create-decision-node-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelState, Point } from '@eclipse-glsp/server-node';
+import { Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { ActivityNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -24,7 +24,7 @@ export class CreateDecisionNodeHandler extends CreateActivityNodeHandler {
     elementTypeIds = [ModelTypes.DECISION_NODE];
     label = 'Decision Node';
 
-    protected override builder(point: Point | undefined, modelState: ModelState): ActivityNodeBuilder {
-        return super.builder(point, modelState).addCssClass('decision');
+    protected override builder(point?: Point): ActivityNodeBuilder {
+        return super.builder(point).addCssClass('decision');
     }
 }

--- a/examples/workflow-server/src/handler/create-fork-or-join-node-handler.ts
+++ b/examples/workflow-server/src/handler/create-fork-or-join-node-handler.ts
@@ -13,14 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelState, Point } from '@eclipse-glsp/server-node';
+import { Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { ActivityNodeBuilder } from '../graph-extension';
 import { CreateActivityNodeHandler } from './create-activity-node-handler';
 
 @injectable()
 export abstract class CreateForkOrJoinNodeHandler extends CreateActivityNodeHandler {
-    protected override builder(point: Point | undefined, modelState: ModelState): ActivityNodeBuilder {
-        return super.builder(point, modelState).addCssClass('forkOrJoin').size(10, 50);
+    protected override builder(point: Point | undefined): ActivityNodeBuilder {
+        return super.builder(point).addCssClass('forkOrJoin').size(10, 50);
     }
 }

--- a/examples/workflow-server/src/handler/create-manual-task-handler.ts
+++ b/examples/workflow-server/src/handler/create-manual-task-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelState, Point } from '@eclipse-glsp/server-node';
+import { Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { TaskNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -24,7 +24,7 @@ export class CreateManualTaskHandler extends CreateTaskHandler {
     elementTypeIds = [ModelTypes.MANUAL_TASK];
     label = 'Manual Task';
 
-    protected override builder(point: Point | undefined, modelState: ModelState): TaskNodeBuilder {
-        return super.builder(point, modelState).addCssClass('manual');
+    protected override builder(point: Point | undefined): TaskNodeBuilder {
+        return super.builder(point).addCssClass('manual');
     }
 }

--- a/examples/workflow-server/src/handler/create-merge-node-handler.ts
+++ b/examples/workflow-server/src/handler/create-merge-node-handler.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { ModelState, Point } from '@eclipse-glsp/server-node';
+import { Point } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { ActivityNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -24,7 +24,7 @@ export class CreateMergeNodeHandler extends CreateActivityNodeHandler {
     elementTypeIds = [ModelTypes.MERGE_NODE];
     label = 'Merge Node';
 
-    protected override builder(point: Point | undefined, modelState: ModelState): ActivityNodeBuilder {
-        return super.builder(point, modelState).addCssClass('merge');
+    protected override builder(point: Point | undefined): ActivityNodeBuilder {
+        return super.builder(point).addCssClass('merge');
     }
 }

--- a/examples/workflow-server/src/handler/create-task-handler.ts
+++ b/examples/workflow-server/src/handler/create-task-handler.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Point } from '@eclipse-glsp/protocol';
-import { CreateNodeOperation, GNode, ModelState } from '@eclipse-glsp/server-node';
+import { CreateNodeOperation, GNode } from '@eclipse-glsp/server-node';
 import { injectable } from 'inversify';
 import { TaskNode, TaskNodeBuilder } from '../graph-extension';
 import { ModelTypes } from '../util/model-types';
@@ -23,10 +23,10 @@ import { CreateWorkflowNodeOperationHandler } from './create-workflow-node-opera
 @injectable()
 export abstract class CreateTaskHandler extends CreateWorkflowNodeOperationHandler {
     createNode(operation: CreateNodeOperation, relativeLocation?: Point): GNode | undefined {
-        return this.builder(relativeLocation, this.modelState).build();
+        return this.builder(relativeLocation).build();
     }
 
-    protected builder(point: Point | undefined, modelState: ModelState): TaskNodeBuilder {
+    protected builder(point: Point | undefined): TaskNodeBuilder {
         return TaskNode.builder()
             .position(point ?? Point.ORIGIN)
             .addCssClass('task')

--- a/packages/server-node/src/di/binding-target.spec.ts
+++ b/packages/server-node/src/di/binding-target.spec.ts
@@ -97,7 +97,12 @@ describe('BindingTarget', () => {
             });
             it('Should throw an error because the given target service is not bound', () => {
                 context.isBound.returns(false);
-                expect(() => applyBindingTarget(context, Target, { service: SubTarget })).to.throw();
+                expect(() => applyBindingTarget(context, Target, { service: SubTarget, autoBind: false })).to.throw();
+            });
+            it('Should bind the unbound target service to itself before applying the toService binding', () => {
+                context.isBound.returns(false);
+                applyBindingTarget(context, Target, { service: SubTarget });
+                expect(context.bind.calledWith(Target)).to.be.true;
             });
             it('The return syntax should be no op and invocation of a syntax function should throw an error', () => {
                 context.isBound.returns(true);


### PR DESCRIPTION
Update behavior of `applyBindingsTarget` for binding `ServiceTargets`.
Add an optional `autoBind` flag to `ServiceTarget` which is enabled by default.
If the target service identifier is not bound yet and this flag is enabled we check
whether the target service can be bound to itself in singleton scope.
If so we do that, otherwise we throw an error.

This covers the most common case for our `ServiceBindings`: Subclassing a default implementation and then bind the service identifier to this implementation.
(e.g. bind(MyModelState).toSelf().inSingletonScope();
bind(ModelState).toService(MyModelState))

For more complex binding configurations its still possible to access the binding context directly (this.context) and apply the bindings this way.
Closes https://github.com/eclipse-glsp/glsp/issues/631
Also: Fix unused model state parameter in workflow builder methods.