### PR TITLE
GH-639 Align ModelState API with Java GLSP Server API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 # Eclipse GLSP Server Node Changelog
 
-## v0.10.0- Upcoming
+## v1.0.0- Upcoming
 
 Inception of the Node GLSP Server.
 This project provides the Node based server component for the Eclipse Graphical Language Platform (GLSP).
 The implementation of this server is aligned with the default Java based [GLSP Server](https://github.com/eclipse-glsp/glsp-server).
-The initial initial implementation was contributed on behalf of STMicroelectronics.
+The [initial implementation](https://github.com/eclipse-glsp/glsp-server-node/commit/4fba8e8beef07798a7eff27c9c04ca68583e5960) has been contributed on behalf of STMicroelectronics.
+The following list composes changes that have been made since the initial implementation.
 
 ### Changes
 
--   [diagram] Implement LayoutEngine API for server-side autolayouting & provide an integration package for layout engines based on ELK. [#509](https://github.com/eclipse-glsp/glsp-server-node/pull/2) [#514](https://github.com/eclipse-glsp/glsp-server-node/pull/5) - Contributed on behalf of STMicroelectronics
+-   [core] Implement `dispatchOnNextUpdate` method that enables queuing of actions that should be dispatched after the next graphical model update. [#1](https://github.com/eclipse-glsp/glsp-server-node/pull/1)
+-   [diagram] Implement LayoutEngine API for server-side autolayouting & provide an integration package for layout engines based on ELK. [#2](https://github.com/eclipse-glsp/glsp-server-node/pull/2) [#5](https://github.com/eclipse-glsp/glsp-server-node/pull/5) - Contributed on behalf of STMicroelectronics
 
 ### Breaking Changes
 
--   [server] Source model refactorings [#582](https://github.com/eclipse-glsp/glsp/issues/582)
+-   [model] Source model refactorings [#11](https://github.com/eclipse-glsp/glsp-server-node/pull/11)
     -   `ModelSourceLoader` → `SourceModelStorage`
     -   Added method to `SourceModelStorage`
+-   [model] Refactor `ModelState` API [#20](https://github.com/eclipse-glsp/glsp-server-node/pull/20)
+    -   Introduce `updateRoot` method
+    -   `DefaultModelState` => make root setter protected
+-   [gmodel] Refactor & Move all base & helper classes for the direct GModel usecase into own `gmodel-lib` subdirectory [#16](https://github.com/eclipse-glsp/glsp-server-node/pull/16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@
 Inception of the Node GLSP Server.
 This project provides the Node based server component for the Eclipse Graphical Language Platform (GLSP).
 The implementation of this server is aligned with the default Java based [GLSP Server](https://github.com/eclipse-glsp/glsp-server).
-The [initial implementation](https://github.com/eclipse-glsp/glsp-server-node/commit/4fba8e8beef07798a7eff27c9c04ca68583e5960) has been contributed on behalf of STMicroelectronics.
+The [initial implementation](https://github.com/eclipse-glsp/glsp-server-node/commit/4fba8e8beef07798a7eff27c9c04ca68583e5960) was contributed on behalf of STMicroelectronics.
 The following list composes changes that have been made since the initial implementation.
 
 ### Changes
 
--   [core] Implement `dispatchOnNextUpdate` method that enables queuing of actions that should be dispatched after the next graphical model update. [#1](https://github.com/eclipse-glsp/glsp-server-node/pull/1)
+-   [core] Implement `dispatchOnNextUpdate` method that enables queuing of actions that should be dispatched after the next graphical model update. [#1](https://github.com/eclipse-glsp/glsp-server-node/pull/1) - Contributed on behalf of STMicroelectronics
 -   [diagram] Implement LayoutEngine API for server-side autolayouting & provide an integration package for layout engines based on ELK. [#2](https://github.com/eclipse-glsp/glsp-server-node/pull/2) [#5](https://github.com/eclipse-glsp/glsp-server-node/pull/5) - Contributed on behalf of STMicroelectronics
 
 ### Breaking Changes

--- a/packages/server-node/src/features/model/model-state.ts
+++ b/packages/server-node/src/features/model/model-state.ts
@@ -27,7 +27,8 @@ export interface ModelState {
     setAll(properties: Record<string, unknown>): void;
     get<P>(key: string, guard?: (object: unknown) => object is P): P | undefined;
     clear(key: string): void;
-    root: GModelRoot;
+    readonly root: GModelRoot;
+    updateRoot(newRoot: GModelRoot): void;
     editMode: string;
     isDirty: boolean;
     sourceUri?: string;
@@ -89,8 +90,12 @@ export class DefaultModelState implements ModelState {
         return this._root;
     }
 
-    public set root(root: GModelRoot) {
-        this.index.indexRoot(root);
+    protected set root(root: GModelRoot) {
         this._root = root;
+    }
+
+    updateRoot(newRoot: GModelRoot): void {
+        this.root = newRoot;
+        this.index.indexRoot(newRoot);
     }
 }

--- a/packages/server-node/src/gmodel-lib/gmodel-storage.ts
+++ b/packages/server-node/src/gmodel-lib/gmodel-storage.ts
@@ -42,7 +42,7 @@ export class GModelStorage extends AbstractJsonModelStorage {
         const sourceUri = this.getSourceUri(action);
         const rootSchema = this.loadFromFile(sourceUri, GModelElementSchema.is);
         const root = this.modelSerializer.createRoot(rootSchema);
-        this.modelState.root = root;
+        this.modelState.updateRoot(root);
     }
 
     saveSourceModel(action: SaveModelAction): MaybePromise<void> {


### PR DESCRIPTION
Introduce `updateRoot` method and make root setter protected
- Update changelog
Fixes https://github.com/eclipse-glsp/glsp/issues/639