### PR TITLE
Layout edges that are children of ports

### DIFF
--- a/packages/layout-elk/src/glsp-elk-layout-engine.ts
+++ b/packages/layout-elk/src/glsp-elk-layout-engine.ts
@@ -240,6 +240,7 @@ export class GlspElkLayoutEngine implements LayoutEngine {
         };
         if (port.children) {
             elkPort.labels = this.findChildren(port, GLabel).map(child => this.transformToElk(child)) as ElkLabel[];
+            this.elkEdges.push(...(this.findChildren(port, GEdge).map(child => this.transformToElk(child)) as ElkEdge[]));
         }
         this.transformShape(elkPort, port);
         this.idToElkElement.set(port.id, elkPort);


### PR DESCRIPTION
Edges that are children of ports should also be layouted by the GlspElkLayoutEngine.

Resolves eclipse-glsp/glsp#661

Contributed on behalf of STMicroelectronics