### PR TITLE
Start with current element

### DIFF
--- a/packages/server-node/src/features/model/gmodel-index.ts
+++ b/packages/server-node/src/features/model/gmodel-index.ts
@@ -177,7 +177,7 @@ export class GModelIndex {
      */
     findParentElement<T extends GModelElement>(elementId: string, guard: TypeGuard<T>): T | undefined {
         const element = this.get(elementId);
-        return element ? this._findElement(element.parent, guard) : undefined;
+        return element ? this._findElement(element, guard) : undefined;
     }
 
     protected _findElement<T>(element: GModelElement, guard: TypeGuard<T>): T | undefined {


### PR DESCRIPTION
I think we should include the current element in the search for an element or parent that matches the guard. This would then be inline with how it is in Sprotty and also better matches the current typedoc (the element to start the search from).