### PR TITLE
Return port with startup complete message

### DIFF
--- a/packages/server-node/src/launch/glsp-server-launcher.ts
+++ b/packages/server-node/src/launch/glsp-server-launcher.ts
@@ -41,7 +41,7 @@ export abstract class GLSPServerLauncher<T = undefined> {
     start(startParams: T): MaybePromise<void> {
         if (!this.running) {
             const result = this.run(startParams);
-            this.running = false;
+            this.running = true;
             return result;
         }
         this.logger.warn('Could not start launcher. Launcher is already running!');

--- a/packages/server-node/src/launch/glsp-server-launcher.ts
+++ b/packages/server-node/src/launch/glsp-server-launcher.ts
@@ -40,8 +40,8 @@ export abstract class GLSPServerLauncher<T = undefined> {
 
     start(startParams: T): MaybePromise<void> {
         if (!this.running) {
-            const result = this.run(startParams);
             this.running = true;
+            const result = this.run(startParams);
             return result;
         }
         this.logger.warn('Could not start launcher. Launcher is already running!');

--- a/packages/server-node/src/launch/socket-server-launcher.ts
+++ b/packages/server-node/src/launch/socket-server-launcher.ts
@@ -19,7 +19,7 @@ import * as jsonrpc from 'vscode-jsonrpc';
 import { GLSPServer, JsonRpcGLSPServer } from '../protocol/glsp-server';
 import { Logger } from '../utils/logger';
 import { GLSPServerLauncher } from './glsp-server-launcher';
-const START_UP_COMPLETE_MSG = '[GLSP-Server]:Startup completed';
+const START_UP_COMPLETE_MSG = '[GLSP-Server]:Startup completed. Accepting requests on port:';
 
 @injectable()
 export class SocketServerLauncher extends GLSPServerLauncher<net.TcpSocketConnectOpts> {
@@ -30,11 +30,24 @@ export class SocketServerLauncher extends GLSPServerLauncher<net.TcpSocketConnec
 
     run(opts: net.TcpSocketConnectOpts): Promise<void> {
         const netServer = net.createServer(socket => this.createClientConnection(socket));
+
         netServer.listen(opts.port, opts.host);
-        this.logger.info(`The GLSP server is ready to accept new client requests on port: ${opts.port}`);
-        // Print a message to the output stream that indicates that the start is completed.
-        // This indicates to the client that the sever process is ready (in an embedded scenario).
-        console.log(this.startupCompleteMessage);
+        netServer.on('listening', () => {
+            const addressInfo = netServer.address();
+            // eslint-disable-next-line no-null/no-null
+            if (addressInfo === null) {
+                this.logger.error('Could not resolve GLSP Server address info');
+                return;
+            } else if (typeof addressInfo === 'string') {
+                this.logger.error('Unexpected type for AddressInfo');
+                return;
+            }
+            const currentPort = addressInfo.port;
+            this.logger.info(`The GLSP server is ready to accept new client requests on port: ${currentPort}`);
+            // Print a message to the output stream that indicates that the start is completed.
+            // This indicates to the client that the server process is ready (in an embedded scenario).
+            console.log(this.startupCompleteMessage.concat(currentPort.toString()));
+        });
         netServer.on('error', () => this.shutdown());
         return new Promise((resolve, reject) => {
             netServer.on('close', () => resolve(undefined));

--- a/packages/server-node/src/launch/socket-server-launcher.ts
+++ b/packages/server-node/src/launch/socket-server-launcher.ts
@@ -34,12 +34,13 @@ export class SocketServerLauncher extends GLSPServerLauncher<net.TcpSocketConnec
         netServer.listen(opts.port, opts.host);
         netServer.on('listening', () => {
             const addressInfo = netServer.address();
-            // eslint-disable-next-line no-null/no-null
-            if (addressInfo === null) {
-                this.logger.error('Could not resolve GLSP Server address info');
+            if (!addressInfo) {
+                this.logger.error('Could not resolve GLSP Server address info. Shutting down.');
+                this.shutdown();
                 return;
             } else if (typeof addressInfo === 'string') {
-                this.logger.error('Unexpected type for AddressInfo');
+                this.logger.error(`GLSP Server is unexpectedly listening to pipe or domain socket "${addressInfo}". Shutting down.`);
+                this.shutdown();
                 return;
             }
             const currentPort = addressInfo.port;


### PR DESCRIPTION
The complete message on startup now returns the port accepting requests.

If the port is set to 0, OS automatically determines an open port. The port returned by the complete message is the effective port (the specified one if port was set and different of 0, and the effective port if port was set to 0).

Contributed on behalf of STMicroelectronics
Signed-off-by: Remi Schnekenburger [rschnekenburger@eclipsesource.com](mailto:rschnekenburger@eclipsesource.com)