### PR TITLE
Fix `stop` of socket server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/node_modules/.bin/mocha",
-      "args": ["--config", "${workspaceRoot}/.mocharc.json", "${relativeFile}"],
+      "args": ["--config", "${workspaceRoot}/.mocharc", "${relativeFile}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "env": {
@@ -20,7 +20,7 @@
       "program": "${workspaceRoot}/node_modules/.bin/mocha",
       "args": [
         "--config",
-        "${workspaceRoot}/.mocharc.json",
+        "${workspaceRoot}/.mocharc",
         "${workspaceRoot}/packages/server-node/src/**/*.spec.ts"
       ],
       "console": "integratedTerminal",
@@ -36,7 +36,7 @@
       "program": "${workspaceRoot}/node_modules/.bin/mocha",
       "args": [
         "--config",
-        "${workspaceRoot}/.mocharc.json",
+        "${workspaceRoot}/.mocharc",
         "${workspaceRoot}/packages/graph/src/**/*.spec.ts"
       ],
       "console": "integratedTerminal",
@@ -52,7 +52,7 @@
       "program": "${workspaceRoot}/node_modules/.bin/mocha",
       "args": [
         "--config",
-        "${workspaceRoot}/.mocharc.json",
+        "${workspaceRoot}/.mocharc",
         "${workspaceRoot}/packages/layout-elk/src/**/*.spec.ts"
       ],
       "console": "integratedTerminal",

--- a/packages/server-node/src/launch/socket-server-launcher.spec.ts
+++ b/packages/server-node/src/launch/socket-server-launcher.spec.ts
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (c) 2022 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { Container } from 'inversify';
+import * as net from 'net';
+import { createAppModule } from '../di/app-module';
+import { defaultSocketLaunchOptions } from './socket-cli-parser';
+import { SocketServerLauncher } from './socket-server-launcher';
+const severPort = 5008;
+describe('test SocketServerLauncher', () => {
+    it('starts and stops', async () => {
+        const appContainer = new Container();
+        appContainer.load(createAppModule(defaultSocketLaunchOptions));
+        const launcher = appContainer.resolve(SocketServerLauncher);
+        launcher.start({ port: severPort });
+        const sockStart = new net.Socket();
+        sockStart.setTimeout(100);
+        const startPromise = new Promise(res => {
+            sockStart
+                .on('connect', () => {
+                    expect(true);
+                    sockStart.destroy();
+                    res(true);
+                })
+                .on('error', e => {
+                    expect.fail('Server is not reachable: ' + e.message);
+                })
+                .on('timeout', () => {
+                    expect.fail('Connection time outed.');
+                })
+                .connect(severPort);
+        });
+        await startPromise;
+        launcher.shutdown();
+        const sockStop = new net.Socket();
+        sockStop.setTimeout(100);
+        const stopPromise = new Promise(res => {
+            sockStop
+                .on('connect', () => {
+                    expect.fail('Server still reachable.');
+                })
+                .on('error', () => {
+                    expect(true);
+                    sockStop.destroy();
+                    res(true);
+                })
+                .on('timeout', () => {
+                    expect.fail('Connection time outed.');
+                })
+                .connect(severPort);
+        });
+        await stopPromise;
+    });
+});


### PR DESCRIPTION
The socket server currently does not actually shutdown the server when calling shutdown.
In order to do so, the `close` method must be called on the server. Thus the server was moved into a private member
to be able to call `close` on `stop`.
This also fixes the test launch config and adds a test. Furthermore the overriden methods in SocketServerLauncher are not public anymore in order to have a clean api.

Contributed on behalf of STMicroelectronics.