### PR TITLE
Support async command execution

### DIFF
--- a/packages/server/src/common/command/command.spec.ts
+++ b/packages/server/src/common/command/command.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { StubCommand } from '../test/mock-util';
+import { expectToThrowAsync, StubCommand } from '../test/mock-util';
 import { CompoundCommand } from './command';
 
 describe('CompoundCommand', () => {
@@ -32,18 +32,18 @@ describe('CompoundCommand', () => {
     });
 
     describe('execute', () => {
-        it('Should execute the subcommands in order', () => {
-            compoundCommand.execute();
+        it('Should execute the subcommands in order', async () => {
+            await compoundCommand.execute();
             expect(command1.execute.calledOnce).to.be.true;
             expect(command2.execute.calledOnce).to.be.true;
             expect(command3.execute.calledOnce).to.be.true;
             expect(command1.execute.calledBefore(command2.execute)).to.be.true;
             expect(command2.execute.calledBefore(command3.execute)).to.be.true;
         });
-        it('Should undo partially executed subcommands in  case of an error', () => {
+        it('Should undo partially executed subcommands in  case of an error', async () => {
             command3.execute.throwsException();
 
-            expect(() => compoundCommand.execute()).to.throw();
+            await expectToThrowAsync(() => compoundCommand.execute());
 
             expect(command1.execute.calledOnce).to.be.true;
             expect(command2.execute.calledOnce).to.be.true;
@@ -54,8 +54,8 @@ describe('CompoundCommand', () => {
     });
 
     describe('undo', () => {
-        it('Should undo the subcommands in reverse order', () => {
-            compoundCommand.undo();
+        it('Should undo the subcommands in reverse order', async () => {
+            await compoundCommand.undo();
             expect(command1.undo.calledOnce).to.be.true;
             expect(command2.undo.calledOnce).to.be.true;
             expect(command3.undo.calledOnce).to.be.true;
@@ -63,10 +63,9 @@ describe('CompoundCommand', () => {
             expect(command2.undo.calledAfter(command3.undo)).to.be.true;
         });
 
-        it('Should redo partially undone subcommands in  case of an error', () => {
+        it('Should redo partially undone subcommands in  case of an error', async () => {
             command1.undo.throwsException();
-
-            expect(() => compoundCommand.undo()).to.throw();
+            await expectToThrowAsync(() => compoundCommand.undo());
 
             expect(command1.undo.calledOnce).to.be.true;
             expect(command2.undo.calledOnce).to.be.true;

--- a/packages/server/src/common/command/command.ts
+++ b/packages/server/src/common/command/command.ts
@@ -106,17 +106,17 @@ export class CompoundCommand implements Command {
         }
     }
 
-    redo(): void {
+    async redo(): Promise<void> {
         const alreadyRedone: Command[] = [];
 
         try {
             for (const command of this.commands) {
-                command.redo();
+                await command.redo();
                 alreadyRedone.unshift(command);
             }
         } catch (err) {
             for (const command of alreadyRedone) {
-                command.undo();
+                await command.undo();
             }
             throw err;
         }

--- a/packages/server/src/common/command/command.ts
+++ b/packages/server/src/common/command/command.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { flatPush, MaybeArray } from '@eclipse-glsp/protocol';
+import { flatPush, MaybeArray, MaybePromise } from '@eclipse-glsp/protocol';
 
 /**
  * A command implements a specific modification of the source model, which can be applied by invoking `execute()`.
@@ -30,19 +30,19 @@ export interface Command {
     /**
      * Performs the command activity required for the effect (e.g. source model change).
      */
-    execute(): void;
+    execute(): MaybePromise<void>;
 
     /**
      * Performs the command activity required to `undo` the effects of a preceding `execute` (or `redo`).
      * The effect, if any, of calling `undo` before `execute` or `redo` have been called, is undefined.
      */
-    undo(): void;
+    undo(): MaybePromise<void>;
 
     /**
      * Performs the command activity required to `redo` the effect after undoing the effect.
      * The effect, if any, of calling `redo` before `undo` is called is undefined.
      */
-    redo(): void;
+    redo(): MaybePromise<void>;
 
     /**
      * Returns whether the command can be undone.
@@ -71,18 +71,18 @@ export class CompoundCommand implements Command {
         flatPush(this.commands, commands);
     }
 
-    execute(): void {
+    async execute(): Promise<void> {
         const alreadyExecuted: Command[] = [];
 
         try {
-            this.commands.forEach(command => {
-                command.execute();
+            for (const command of this.commands) {
+                await command.execute();
                 alreadyExecuted.unshift(command);
-            });
+            }
         } catch (err) {
             for (const command of alreadyExecuted) {
                 if (Command.canUndo(command)) {
-                    command.undo();
+                    await command.undo();
                 } else {
                     break;
                 }
@@ -91,15 +91,17 @@ export class CompoundCommand implements Command {
         }
     }
 
-    undo(): void {
+    async undo(): Promise<void> {
         const alreadyUndone: Command[] = [];
         try {
-            [...this.commands].reverse().forEach(command => {
-                command.undo();
+            for (const command of [...this.commands].reverse()) {
+                await command.undo();
                 alreadyUndone.unshift(command);
-            });
+            }
         } catch (err) {
-            alreadyUndone.forEach(command => command.redo());
+            for (const command of alreadyUndone) {
+                await command.redo();
+            }
             throw err;
         }
     }
@@ -108,12 +110,14 @@ export class CompoundCommand implements Command {
         const alreadyRedone: Command[] = [];
 
         try {
-            this.commands.forEach(command => {
+            for (const command of this.commands) {
                 command.redo();
                 alreadyRedone.unshift(command);
-            });
+            }
         } catch (err) {
-            alreadyRedone.forEach(command => command.undo());
+            for (const command of alreadyRedone) {
+                command.undo();
+            }
             throw err;
         }
     }

--- a/packages/server/src/common/command/recording-command.spec.ts
+++ b/packages/server/src/common/command/recording-command.spec.ts
@@ -39,36 +39,36 @@ describe('RecordingCommand', () => {
         beforeState = JSON.parse(JSON.stringify(jsonObject));
     });
 
-    it('should be undoable after execution', () => {
+    it('should be undoable after execution', async () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         const command = new RecordingCommand(jsonObject, () => {});
         expect(command.canUndo()).to.be.false;
-        command.execute();
+        await command.execute();
         expect(command.canUndo()).to.be.true;
     });
 
-    it('should restore the pre execution state when undo is called', () => {
+    it('should restore the pre execution state when undo is called', async () => {
         const command = new RecordingCommand(jsonObject, () => {
             jsonObject.string = 'bar';
             jsonObject.flag = false;
             jsonObject.maybe = { hello: 'world' };
         });
-        command.execute();
+        await command.execute();
         expect(jsonObject).to.not.be.deep.equals(beforeState);
-        command.undo();
+        await command.undo();
         expect(jsonObject).to.be.deep.equals(beforeState);
     });
 
-    it('should restore the post execution state when redo is called', () => {
+    it('should restore the post execution state when redo is called', async () => {
         const command = new RecordingCommand(jsonObject, () => {
             jsonObject.string = 'bar';
             jsonObject.flag = false;
             jsonObject.maybe = { hello: 'world' };
         });
-        command.execute();
+        await command.execute();
         const afterState = JSON.parse(JSON.stringify(jsonObject));
         jsonObject = JSON.parse(JSON.stringify(afterState));
-        command.redo();
+        await command.redo();
         expect(jsonObject).to.be.deep.equals(afterState);
     });
 });

--- a/packages/server/src/common/command/undo-redo-action-handler.ts
+++ b/packages/server/src/common/command/undo-redo-action-handler.ts
@@ -39,17 +39,17 @@ export class UndoRedoActionHandler implements ActionHandler {
         return [];
     }
 
-    protected undo(): MaybePromise<Action[]> {
+    protected async undo(): Promise<Action[]> {
         if (this.commandStack.canUndo()) {
-            this.commandStack.undo();
+            await this.commandStack.undo();
             return this.modelSubmissionHandler.submitModel('undo');
         }
         return [];
     }
 
-    protected redo(): MaybePromise<Action[]> {
+    protected async redo(): Promise<Action[]> {
         if (this.commandStack.canRedo()) {
-            this.commandStack.redo();
+            await this.commandStack.redo();
             return this.modelSubmissionHandler.submitModel('redo');
         }
         return [];

--- a/packages/server/src/common/operations/operation-action-handler.ts
+++ b/packages/server/src/common/operations/operation-action-handler.ts
@@ -66,13 +66,13 @@ export class OperationActionHandler implements ActionHandler {
     protected async executeHandler(operation: Operation, handler: OperationHandler): Promise<Action[]> {
         const command = await handler.execute(operation);
         if (command) {
-            this.executeCommand(command);
+            await this.executeCommand(command);
         }
         return this.modelSubmissionHandler.submitModel('operation');
     }
 
-    protected executeCommand(command: Command): void {
-        this.commandStack.execute(command);
+    protected async executeCommand(command: Command): Promise<void> {
+        return this.commandStack.execute(command);
     }
 
     protected submitModel(): MaybePromise<Action[]> {

--- a/packages/server/src/common/test/mock-util.ts
+++ b/packages/server/src/common/test/mock-util.ts
@@ -25,11 +25,13 @@ import {
     EdgeTypeHint,
     InitializeClientSessionParameters,
     MaybeArray,
+    MaybePromise,
     Point,
     RequestEditValidationAction,
     ShapeTypeHint,
     ValidationStatus
 } from '@eclipse-glsp/protocol';
+import { expect } from 'chai';
 import { Container } from 'inversify';
 import { MessageConnection } from 'vscode-jsonrpc';
 import { ActionDispatcher } from '../actions/action-dispatcher';
@@ -51,6 +53,25 @@ import { Logger, LogLevel } from '../utils/logger';
 
 export async function delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Consumes a maybe async function and checks for error
+ * @param  method - The function to check
+ * @param  message - Optional message to match with error message
+ */
+export async function expectToThrowAsync(toEvaluate: () => MaybePromise<void>, message?: string): Promise<void> {
+    let err: Error | undefined = undefined;
+    try {
+        await toEvaluate();
+    } catch (error: any) {
+        err = error;
+    }
+    if (message) {
+        expect(err?.message).to.be.equal(message);
+    } else {
+        expect(err).to.be.an('Error');
+    }
 }
 
 export function createClientSession(


### PR DESCRIPTION
Change command API to support `MaybePromise<void>` instead of just plain voids. This enables async command execution e.g. for communicating with a modelserver 
Contributed on behalf of STMicroelectronics