### PR TITLE
feat: adjust server startup to use autoassigned ports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,6 +66,7 @@
       "request": "launch",
       "name": "Debug Workflow Example Server",
       "program": "${workspaceFolder}/examples/workflow-server/bundle/wf-glsp-server-node.js",
+      "args": ["--port", "5007"],
       "env": {
         "NODE_ENV": "development"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
         -   Refactored `CreateOperationHandler` to an interface instead of a class
         -   Renamed the services and handlers of the direct GModel library => consistent use of `GModel` prefix
         -   The `ModelState` interface no longer has an `isDirty` flag. Dirty state is now handled by the `CommandStack`
+-   [server] Default port has changed from 5007 (and 8081 for websocket) to 0, which implies autoassignment by the OS [#42](https://github.com/eclipse-glsp/glsp-server-node/pull/42)
 
 ## [v1.0.0 - 30/06/2022](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v1.0.0)
 

--- a/examples/workflow-server/package.json
+++ b/examples/workflow-server/package.json
@@ -49,7 +49,7 @@
     "lint": "eslint --ext .ts,.tsx ./src",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",
     "prepare": "yarn clean && yarn build",
-    "start": "node --enable-source-maps bundle/wf-glsp-server-node.js",
+    "start": "node --enable-source-maps bundle/wf-glsp-server-node.js --port 5007",
     "start:websocket": "node --enable-source-maps bundle/wf-glsp-server-node.js -w --port 8081",
     "watch": "tsc -w"
   },

--- a/packages/server/src/node/launch/socket-cli-parser.ts
+++ b/packages/server/src/node/launch/socket-cli-parser.ts
@@ -23,7 +23,7 @@ export interface SocketLaunchOptions extends LaunchOptions {
 
 export const defaultSocketLaunchOptions: Required<SocketLaunchOptions> = {
     ...defaultLaunchOptions,
-    port: 5007,
+    port: 0,
     host: 'localhost'
 };
 


### PR DESCRIPTION
This sets the default port to 0, which will cause the server to automatically assign a port. The port is then printed to the console in the startup message and can be parsed by clients.

Part of eclipse-glsp/glsp#965