### PR TITLE
GLSP-813 Also publish workflow-server bundle

### DIFF
--- a/examples/workflow-server/package.json
+++ b/examples/workflow-server/package.json
@@ -43,7 +43,8 @@
     "node.js",
     "node.d.ts",
     "browser.d.ts",
-    "browser.js"
+    "browser.js",
+    "bundle"
   ],
   "scripts": {
     "build": "tsc -b && yarn bundle",


### PR DESCRIPTION
Ensure that bundled example-server is part of the published package contents so that it can be reused in the dev-examples
Part of https://github.com/eclipse-glsp/glsp/issues/813