### PR TITLE
GLSP-77: Allow WebSocket connections to reconnect after interrupt

### DIFF
--- a/packages/server/src/common/features/model/request-model-action-handler.ts
+++ b/packages/server/src/common/features/model/request-model-action-handler.ts
@@ -17,6 +17,7 @@ import { Action, RequestModelAction, ServerStatusAction } from '@eclipse-glsp/pr
 import { inject, injectable } from 'inversify';
 import { ActionDispatcher } from '../../actions/action-dispatcher';
 import { ActionHandler } from '../../actions/action-handler';
+import { ClientOptionsUtil } from '../../utils/client-options-util';
 import { Logger } from '../../utils/logger';
 import { ProgressMonitor, ProgressService } from '../progress/progress-service';
 import { ModelState } from './model-state';
@@ -49,8 +50,24 @@ export class RequestModelActionHandler implements ActionHandler {
         this.logger.debug('Execute RequestModelAction:', action);
         this.modelState.setAll(action.options ?? {});
 
+        const isReconnecting = ClientOptionsUtil.isReconnecting(action.options);
+
         const progress = this.reportModelLoading('Model loading in progress');
-        await this.sourceModelStorage.loadSourceModel(action);
+
+        if (isReconnecting) {
+            const oldModelRoot = this.modelState.root;
+            if (oldModelRoot) {
+                // use current modelRoot of modelState and submit
+                this.modelState.updateRoot(oldModelRoot);
+                // decrease revision by one, as each submit will increase it by one;
+                // the next save would produce warning that source model was changed otherwise
+                this.modelState.root.revision = (this.modelState.root.revision ?? 0) - 1;
+            } else {
+                await this.sourceModelStorage.loadSourceModel(action);
+            }
+        } else {
+            await this.sourceModelStorage.loadSourceModel(action);
+        }
         this.reportModelLoadingFinished(progress);
 
         return this.submissionHandler.submitModel();

--- a/packages/server/src/common/utils/client-options-util.ts
+++ b/packages/server/src/common/utils/client-options-util.ts
@@ -13,10 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Args } from '@eclipse-glsp/protocol';
+import { ArgsUtil } from './args-util';
+
 export class ClientOptionsUtil {
     private static FILE_PREFIX = 'file://';
+    public static IS_RECONNECTING = 'isReconnecting';
 
     public static adaptUri(uri: string): string {
         return uri.replace(this.FILE_PREFIX, '');
+    }
+
+    public static isReconnecting(options?: Args): boolean {
+        return ArgsUtil.getBoolean(options, ClientOptionsUtil.IS_RECONNECTING);
     }
 }


### PR DESCRIPTION
If Websocket connections reconnect after an interrupt, ensure that the last modelState is restored on RequestModelAction if available

Part of https://github.com/eclipse-glsp/glsp/issues/77

---

Related to: https://github.com/eclipse-glsp/glsp-client/pull/269