### PR TITLE
GLSP-1101: Fix Windows path  conversion

### DIFF
--- a/examples/workflow-server-bundled/package.json
+++ b/examples/workflow-server-bundled/package.json
@@ -41,7 +41,7 @@
     "wf-glsp-server-node.js.map"
   ],
   "scripts": {
-    "clean": "rimraf ./*.js./*.js.map",
+    "clean": "rimraf wf-glsp-server-node.js wf-glsp-server-node.js.map",
     "prepare": "yarn clean",
     "start": "node --enable-source-maps ./wf-glsp-server-node.js --port 5007",
     "start:websocket": "node --enable-source-maps ./wf-glsp-server-node.js -w --port 8081",

--- a/packages/server/src/node/abstract-json-model-storage.ts
+++ b/packages/server/src/node/abstract-json-model-storage.ts
@@ -16,6 +16,7 @@
 import { MaybePromise, RequestModelAction, SaveModelAction, TypeGuard } from '@eclipse-glsp/protocol';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
+import * as os from 'os';
 import { fileURLToPath } from 'url';
 import { ModelState, SOURCE_URI_ARG } from '../common/features/model/model-state';
 import { SourceModelStorage } from '../common/features/model/source-model-storage';
@@ -91,7 +92,12 @@ export abstract class AbstractJsonModelStorage implements SourceModelStorage {
     }
 
     protected toPath(sourceUri: string): string {
-        return sourceUri.startsWith('file://') ? fileURLToPath(sourceUri) : sourceUri;
+        let path = sourceUri.startsWith('file://') ? fileURLToPath(sourceUri) : sourceUri;
+        if (os.platform() === 'win32') {
+            // Remove the leading slash if it exists (Windows paths don't have it)
+            path = path.replace(/^\//, '');
+        }
+        return path;
     }
 
     protected getFileUri(action: SaveModelAction): string {


### PR DESCRIPTION
Ensure leading shashes in File urls are properly handled under Windows. 
Also: Fix rimraf command that was not working under Windows 
Fixes https://github.com/eclipse-glsp/glsp/issues/1101