### PR TITLE
GLSP-1109: Remove dependency to fs-extra

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -68,7 +68,6 @@
     "ws": "^8.12.1"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13",
     "@types/ws": "^8.5.4"
   },
   "peerDependencies": {

--- a/packages/server/src/node/abstract-json-model-storage.ts
+++ b/packages/server/src/node/abstract-json-model-storage.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { MaybePromise, RequestModelAction, SaveModelAction, TypeGuard } from '@eclipse-glsp/protocol';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
 import { fileURLToPath } from 'url';

--- a/packages/server/src/node/launch/cli-parser.ts
+++ b/packages/server/src/node/launch/cli-parser.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import * as cmd from 'commander';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import * as path from 'path';
 import { LogLevel, LoggerConfigOptions, asLogLevel } from '../../common/utils/logger';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,13 +1114,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
-"@types/fs-extra@^9.0.13":
-  version "9.0.13"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
-  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"


### PR DESCRIPTION
Use 'fs' instead of 'fs-extra' in GLSP server node as the additional capatibilities of 'fs-extra' are not used. Also fixes the issue that the dependency to 'fs-extra' was not declared in the 'package.json' which might fail consumer builds.

Contributed on behalf of STMicroelectronics.