### PR TITLE
GLSP-891: Json operation handler API

### DIFF
--- a/examples/workflow-server/webpack.config.js
+++ b/examples/workflow-server/webpack.config.js
@@ -57,6 +57,6 @@ module.exports = env => {
                 }
             ]
         },
-        ignoreWarnings: [/Failed to parse source map/]
+        ignoreWarnings: [/Failed to parse source map/, /Can't resolve .* in '.*ws\/lib'/]
     };
 };

--- a/packages/server/src/common/features/model/model-state.ts
+++ b/packages/server/src/common/features/model/model-state.ts
@@ -92,6 +92,9 @@ export class DefaultModelState implements ModelState {
     }
 
     updateRoot(newRoot: GModelRoot): void {
+        if (!newRoot.revision && this.root) {
+            newRoot.revision = this.root.revision;
+        }
         this.root = newRoot;
         this.index.indexRoot(newRoot);
     }

--- a/packages/server/src/common/features/model/model-submission-handler.ts
+++ b/packages/server/src/common/features/model/model-submission-handler.ts
@@ -110,9 +110,9 @@ export class ModelSubmissionHandler {
 
         const revision = this.requestModelAction ? 0 : this.modelState.root.revision! + 1;
         this.modelState.root.revision = revision;
-        const root = this.serializeGModel();
 
         if (this.diagramConfiguration.needsClientLayout) {
+            const root = this.serializeGModel();
             return [RequestBoundsAction.create(root), SetDirtyStateAction.create(this.commandStack.isDirty, { reason })];
         }
         return this.submitModelDirectly(reason);

--- a/packages/server/src/common/gmodel/gmodel-create-edge-operation-handler.ts
+++ b/packages/server/src/common/gmodel/gmodel-create-edge-operation-handler.ts
@@ -19,7 +19,7 @@ import { GNode } from '@eclipse-glsp/graph/lib/gnode';
 import { CreateEdgeOperation, MaybePromise, TriggerEdgeCreationAction } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
 import { Command } from '../command/command';
-import { CreateOperationHandler, CreateOperationKind } from '../operations/create-operation-handler';
+import { CreateEdgeOperationHandler } from '../operations/create-operation-handler';
 import { GModelOperationHandler } from './gmodel-operation-handler';
 
 /**
@@ -28,8 +28,8 @@ import { GModelOperationHandler } from './gmodel-operation-handler';
  * (i.e. all operation handlers directly modify the graphical model).
  */
 @injectable()
-export abstract class GModelCreateEdgeOperationHandler extends GModelOperationHandler implements CreateOperationHandler {
-    override readonly operationType: CreateOperationKind = CreateEdgeOperation.KIND;
+export abstract class GModelCreateEdgeOperationHandler extends GModelOperationHandler implements CreateEdgeOperationHandler {
+    override readonly operationType = CreateEdgeOperation.KIND;
     abstract override label: string;
     abstract elementTypeIds: string[];
 

--- a/packages/server/src/common/gmodel/gmodel-create-node-operation-handler.ts
+++ b/packages/server/src/common/gmodel/gmodel-create-node-operation-handler.ts
@@ -19,7 +19,7 @@ import { CreateNodeOperation, MaybePromise, Point, SelectAction, TriggerNodeCrea
 import { inject, injectable } from 'inversify';
 import { ActionDispatcher } from '../actions/action-dispatcher';
 import { Command } from '../command/command';
-import { CreateOperationHandler, CreateOperationKind } from '../operations/create-operation-handler';
+import { CreateNodeOperationHandler } from '../operations/create-operation-handler';
 import { getRelativeLocation } from '../utils/layout-util';
 import { GModelOperationHandler } from './gmodel-operation-handler';
 
@@ -29,7 +29,7 @@ import { GModelOperationHandler } from './gmodel-operation-handler';
  * (i.e. all operation handlers directly modify the graphical model).
  */
 @injectable()
-export abstract class GModelCreateNodeOperationHandler extends GModelOperationHandler implements CreateOperationHandler {
+export abstract class GModelCreateNodeOperationHandler extends GModelOperationHandler implements CreateNodeOperationHandler {
     @inject(ActionDispatcher)
     protected actionDispatcher: ActionDispatcher;
 
@@ -37,7 +37,7 @@ export abstract class GModelCreateNodeOperationHandler extends GModelOperationHa
 
     abstract override label: string;
 
-    override operationType: CreateOperationKind = CreateNodeOperation.KIND;
+    override readonly operationType = CreateNodeOperation.KIND;
 
     override createCommand(operation: CreateNodeOperation): MaybePromise<Command | undefined> {
         return this.commandOf(() => this.executeCreation(operation));

--- a/packages/server/src/common/index.ts
+++ b/packages/server/src/common/index.ts
@@ -71,6 +71,7 @@ export * from './gmodel/index';
 export * from './launch/glsp-server-launcher';
 export * from './operations/compound-operation-handler';
 export * from './operations/create-operation-handler';
+export * from './operations/json-operation-handler';
 export * from './operations/operation-action-handler';
 export * from './operations/operation-handler';
 export * from './operations/operation-handler-registry';

--- a/packages/server/src/common/operations/compound-operation-handler.ts
+++ b/packages/server/src/common/operations/compound-operation-handler.ts
@@ -19,6 +19,11 @@ import { Command, CompoundCommand } from '../command/command';
 import { OperationHandler } from './operation-handler';
 import { OperationHandlerRegistry } from './operation-handler-registry';
 
+/**
+ * Generic {@link OperationHandler} from {@link CompoundOperations}.
+ * Retrieves the corresponding execution commands for the list of (sub) operations
+ * and constructs a {@link CompoundCommand} for them.
+ */
 @injectable()
 export class CompoundOperationHandler extends OperationHandler {
     @inject(OperationHandlerRegistry)
@@ -27,7 +32,7 @@ export class CompoundOperationHandler extends OperationHandler {
     operationType = CompoundOperation.KIND;
 
     async createCommand(operation: CompoundOperation): Promise<Command | undefined> {
-        const maybeCommands = operation.operationList.map(op => this.operationHandlerRegistry.getExecutableCommand(op));
+        const maybeCommands = operation.operationList.map(op => this.operationHandlerRegistry.getOperationHandler(op)?.execute(op));
         const commands: Command[] = [];
 
         for await (const command of maybeCommands) {

--- a/packages/server/src/common/operations/create-operation-handler.ts
+++ b/packages/server/src/common/operations/create-operation-handler.ts
@@ -19,21 +19,37 @@ import {
     hasArrayProp,
     hasFunctionProp,
     hasStringProp,
+    MaybePromise,
     TriggerEdgeCreationAction,
     TriggerNodeCreationAction
 } from '@eclipse-glsp/protocol';
+import { Command } from '../command/command';
 import { OperationHandler } from './operation-handler';
 
 /**
- * A special {@link OperationHandler} that is responsible for the handling of {@link CreateOperation}s. Depending on its
+ * A special {@link OperationHandler} that is responsible for the handling of (a subset of) {@link CreateEdgeOperation}s. Depending on its
  * operation type the triggered actions are {@link TriggerNodeCreationAction} or {@link TriggerEdgeCreationAction}s.
  */
-export interface CreateOperationHandler extends OperationHandler {
+export interface CreateEdgeOperationHandler extends OperationHandler {
+    label: string;
+    elementTypeIds: string[];
+    operationType: typeof CreateEdgeOperation.KIND;
+    getTriggerActions(): TriggerEdgeCreationAction[];
+    createCommand(operation: CreateEdgeOperation): MaybePromise<Command | undefined>;
+}
+
+export interface CreateNodeOperationHandler extends OperationHandler {
     readonly label: string;
     elementTypeIds: string[];
-    operationType: CreateOperationKind;
-    getTriggerActions(): (TriggerEdgeCreationAction | TriggerNodeCreationAction)[];
+    operationType: typeof CreateNodeOperation.KIND;
+    getTriggerActions(): TriggerNodeCreationAction[];
+    createCommand(operation: CreateNodeOperation): MaybePromise<Command | undefined>;
 }
+/**
+ * A special {@link OperationHandler} that is responsible for the handling of a node or edge creation operation. Depending on its
+ * operation type the triggered actions are {@link TriggerNodeCreationAction} or {@link TriggerEdgeCreationAction}s.
+ */
+export type CreateOperationHandler = CreateNodeOperationHandler | CreateEdgeOperationHandler;
 
 export type CreateOperationKind = typeof CreateNodeOperation.KIND | typeof CreateEdgeOperation.KIND;
 
@@ -41,9 +57,10 @@ export namespace CreateOperationHandler {
     export function is(object: unknown): object is CreateOperationHandler {
         return (
             object instanceof OperationHandler &&
+            hasStringProp(object, 'operationType') &&
             hasStringProp(object, 'label') &&
             hasArrayProp(object, 'elementTypeIds') &&
-            hasFunctionProp(object, 'getTriggerActions')
+            hasFunctionProp(object, 'getTriggerActions', true)
         );
     }
 }

--- a/packages/server/src/common/operations/json-operation-handler.ts
+++ b/packages/server/src/common/operations/json-operation-handler.ts
@@ -1,0 +1,147 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { GModelElement } from '@eclipse-glsp/graph';
+import {
+    AnyObject,
+    CreateEdgeOperation,
+    CreateNodeOperation,
+    MaybePromise,
+    Point,
+    TriggerEdgeCreationAction,
+    TriggerNodeCreationAction,
+    hasFunctionProp,
+    hasObjectProp
+} from '@eclipse-glsp/protocol';
+import { injectable } from 'inversify';
+import { Command } from '../command/command';
+import { AbstractRecordingCommand } from '../command/recording-command';
+import { ModelState } from '../features/model/model-state';
+import { getRelativeLocation } from '../utils/layout-util';
+import { CreateEdgeOperationHandler, CreateNodeOperationHandler } from './create-operation-handler';
+import { OperationHandler } from './operation-handler';
+
+/**
+ * Helper interface for {@link ModelState} implementations of diagram languages that use a (serializable) JSON-based source model.
+ * Has to be implemented in order to reuse the {@link JsonOperationHandler} API.
+ */
+export interface JsonModelState<JsonObject extends AnyObject = AnyObject> extends ModelState {
+    readonly sourceModel: JsonObject;
+    updateSourceModel(sourceModel: JsonObject): void;
+}
+
+export namespace JsonModelState {
+    export function is(modelState: ModelState): modelState is JsonModelState {
+        return hasObjectProp(modelState, 'sourceModel') && hasFunctionProp(modelState, 'updateSourceModel');
+    }
+}
+
+/**
+ * Simple base implementation of {@link AbstractRecordingCommand} that allows recording of changes made
+ * to the `sourceModel` of the given {@link JsonModelState} during the given `doExecute` function
+ */
+export class JsonRecordingCommand<JsonObject extends AnyObject = AnyObject> extends AbstractRecordingCommand<JsonObject> {
+    constructor(protected modelState: JsonModelState<JsonObject>, protected doExecute: () => MaybePromise<void>) {
+        super();
+    }
+
+    protected override getJsonObject(): MaybePromise<JsonObject> {
+        return this.modelState.sourceModel;
+    }
+
+    protected override postChange(newModel: JsonObject): MaybePromise<void> {
+        this.modelState.updateSourceModel(newModel);
+    }
+}
+
+/**
+ * Reusable {@link OperationHandler} base implementation for diagram languages that use a (serializable) JSON-based source model.
+ * To use this class (or its subclasses) the injected {@link ModelState} has to implement the {@link JsonModelState} interface.
+ *
+ */
+@injectable()
+export abstract class JsonOperationHandler extends OperationHandler {
+    protected commandOf(runnable: () => void): Command {
+        if (!JsonModelState.is(this.modelState)) {
+            throw new Error('Cannot create command. The underlying model state does not implement the `JsonModelState` interface');
+        }
+        return new JsonRecordingCommand(this.modelState, runnable);
+    }
+}
+
+/**
+ * Reusable {@link CreateNodeOperationHandler} base implementation for diagram languages that use a (serializable) JSON-based source model.
+ */
+@injectable()
+export abstract class JsonCreateNodeOperationHandler extends JsonOperationHandler implements CreateNodeOperationHandler {
+    abstract elementTypeIds: string[];
+    abstract override label: string;
+    override readonly operationType = CreateNodeOperation.KIND;
+
+    abstract override createCommand(operation: CreateNodeOperation): MaybePromise<Command | undefined>;
+
+    getTriggerActions(): TriggerNodeCreationAction[] {
+        return this.elementTypeIds.map(typeId => TriggerNodeCreationAction.create(typeId));
+    }
+
+    /**
+     * Return the GModelElement that will contain the newly created node. It is usually
+     * the target element ({@link CreateNodeOperation.containerId}), but could also
+     * be e.g. an intermediate compartment, or even a different Node.
+     *
+     * @param operation
+     * @return the GModelElement that will contain the newly created node.
+     */
+    getContainer(operation: CreateNodeOperation): GModelElement | undefined {
+        const index = this.modelState.index;
+        return operation.containerId ? index.get(operation.containerId) : undefined;
+    }
+
+    getLocation(operation: CreateNodeOperation): Point | undefined {
+        return operation.location;
+    }
+
+    /**
+     * Retrieves the diagram absolute location and the target container from the given {@link CreateNodeOperation}
+     * and converts the absolute location to coordinates relative to the given container.
+     *  Relative coordinates can only be retrieved if the given container element is part of
+     * a hierarchy of {@link GBoundsAware} elements. This means each (recursive) parent element need to
+     * implement {@link GBoundsAware}. If that is not the case this method returns `undefined`.
+     * @param absoluteLocation The diagram absolute position.
+     * @param container The container element.
+     * @returns The relative position or `undefined`.
+     */
+    getRelativeLocation(operation: CreateNodeOperation): Point | undefined {
+        const container = this.getContainer(operation) ?? this.modelState.root;
+        const absoluteLocation = this.getLocation(operation) ?? Point.ORIGIN;
+        return getRelativeLocation(absoluteLocation, container);
+    }
+}
+
+/**
+ * Reusable {@link CreateEdgeOperationHandler} base implementation for diagram languages that use a (serializable) JSON-based source model.
+ */
+@injectable()
+export abstract class JsonCreateEdgeOperationHandler extends JsonOperationHandler implements CreateEdgeOperationHandler {
+    abstract elementTypeIds: string[];
+    abstract override label: string;
+    override readonly operationType = CreateEdgeOperation.KIND;
+
+    abstract override createCommand(operation: CreateEdgeOperation): MaybePromise<Command | undefined>;
+
+    getTriggerActions(): TriggerEdgeCreationAction[] {
+        return this.elementTypeIds.map(typeId => TriggerEdgeCreationAction.create(typeId));
+    }
+}

--- a/packages/server/src/common/operations/operation-handler-registry.ts
+++ b/packages/server/src/common/operations/operation-handler-registry.ts
@@ -13,9 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Args, CreateOperation, MaybePromise, Operation } from '@eclipse-glsp/protocol';
+import { Args, CreateOperation, Operation } from '@eclipse-glsp/protocol';
 import { inject, injectable, optional } from 'inversify';
-import { Command } from '../command/command';
 import { ClientSessionInitializer } from '../session/client-session-initializer';
 import { Registry } from '../utils/registry';
 import { CreateOperationHandler } from './create-operation-handler';
@@ -34,16 +33,6 @@ export class OperationHandlerRegistry extends Registry<string, OperationHandler>
 
     getOperationHandler(operation: Operation): OperationHandler | undefined {
         return CreateOperation.is(operation) ? this.get(`${operation.kind}_${operation.elementTypeId}`) : this.get(operation.kind);
-    }
-
-    /**
-     * Returns the matching command for the given operation.
-     *
-     * @param operation operation
-     * @return the matching command for the given operation
-     */
-    getExecutableCommand(operation: Operation): MaybePromise<Command | undefined> {
-        return this.getOperationHandler(operation)?.createCommand(operation);
     }
 }
 

--- a/packages/server/src/common/operations/operation-handler.ts
+++ b/packages/server/src/common/operations/operation-handler.ts
@@ -37,7 +37,7 @@ export abstract class OperationHandler {
      *
      * @returns the operation type that can be handled.
      */
-    abstract operationType: string;
+    abstract readonly operationType: string;
 
     readonly label?: string;
 
@@ -46,7 +46,7 @@ export abstract class OperationHandler {
      * is performed on the model(s).
      *
      * @param operation The operation to process.
-     * @return The created command to be executed on the command stack or `undefined` nothing should be done.
+     * @return The created command to be executed on the command stack or `undefined` if nothing should be done.
      */
     abstract createCommand(operation: Operation): MaybePromise<Command | undefined>;
 

--- a/packages/server/src/common/utils/registry.spec.ts
+++ b/packages/server/src/common/utils/registry.spec.ts
@@ -13,14 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { MultiRegistry, Registry } from './registry';
 import { expect } from 'chai';
+import { NullLogger } from './logger';
+import { MultiRegistry, Registry } from './registry';
 
 describe('Test Registry', () => {
     let registry: Registry<string, string>;
 
     beforeEach(() => {
         registry = new Registry();
+        registry['logger'] = new NullLogger();
     });
 
     it('register - with new key-value pair', () => {

--- a/packages/server/src/common/utils/registry.ts
+++ b/packages/server/src/common/utils/registry.ts
@@ -14,7 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { remove } from '@eclipse-glsp/protocol/lib/utils/array-util';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
+import { Logger } from './logger';
 
 /**
  * A registry manages a set of key-value pairs and provides query functionality. In GLSP this is typically used to
@@ -27,6 +28,9 @@ import { injectable } from 'inversify';
 
 @injectable()
 export class Registry<K, V> {
+    @inject(Logger)
+    protected logger: Logger;
+
     protected elements: Map<K, V> = new Map();
     /**
      * Registers a new key-value pair.
@@ -36,11 +40,12 @@ export class Registry<K, V> {
      * @returns `true` if the pair was registered successfully, `false` if another pair with the same key is already
      *         registered.
      */
-    register(key: K, instance: V): boolean {
+    register(key: K, value: V): boolean {
         if (!this.hasKey(key)) {
-            this.elements.set(key, instance);
+            this.elements.set(key, value);
             return true;
         }
+        this.logger.warn('Could not register key-value pair. Key is already registered', { key, value });
         return false;
     }
 


### PR DESCRIPTION
- Provides  generic,reusable operation handler implementations for JSON-based source models
- Refactor `RecordingCommand` API
- Refactor `CreationOperationHandler` interfaces to be more strict (Previously it was possible to  declare a handler with mixed (nodes/edges) types) 
- Also: Filter out non-critical warning in webpack config

 Fixes https://github.com/eclipse-glsp/glsp/issues/891

For testing use: https://github.com/eclipse-glsp/glsp-examples/pull/193