### PR TITLE
Bugfixes for 2.0

### DIFF
--- a/packages/server/src/common/gmodel/cut-operation-handler.ts
+++ b/packages/server/src/common/gmodel/cut-operation-handler.ts
@@ -28,9 +28,11 @@ export class GModelCutOperationHandler extends GModelOperationHandler {
 
     createCommand(operation: CutOperation): MaybePromise<Command | undefined> {
         const cuttableElementIds = this.getElementToCut(operation);
-        return cuttableElementIds.length > 0 //
-            ? this.commandOf(() => this.actionDispatcher.dispatch(DeleteElementOperation.create(cuttableElementIds)))
-            : undefined;
+        // If we have cuttable elements we dispatch a DeleteElementOperation otherwise do nothing
+        if (cuttableElementIds.length > 0) {
+            this.actionDispatcher.dispatch(DeleteElementOperation.create(cuttableElementIds));
+        }
+        return undefined;
     }
 
     protected getElementToCut(cutOperation: CutOperation): string[] {

--- a/packages/server/src/common/gmodel/delete-operation-handler.ts
+++ b/packages/server/src/common/gmodel/delete-operation-handler.ts
@@ -72,7 +72,7 @@ export class GModelDeleteOperationHandler extends GModelOperationHandler {
         }
 
         const dependents = new Set<GModelElement>();
-        this.collectDependents(dependents, nodeToDelete);
+        this.collectDependents(dependents, nodeToDelete, false);
 
         dependents.forEach(dependant => {
             const index = this.modelState.root.children.findIndex(element => element === dependant);
@@ -85,22 +85,23 @@ export class GModelDeleteOperationHandler extends GModelOperationHandler {
         return true;
     }
 
-    protected collectDependents(dependents: Set<GModelElement>, nodeToDelete: GModelElement): void {
+    protected collectDependents(dependents: Set<GModelElement>, nodeToDelete: GModelElement, isChild: boolean): void {
         if (dependents.has(nodeToDelete)) {
             return;
         }
 
         if (nodeToDelete.children.length > 0) {
-            nodeToDelete.children.forEach(child => this.collectDependents(dependents, child));
+            nodeToDelete.children.forEach(child => this.collectDependents(dependents, child, true));
         }
 
         if (nodeToDelete instanceof GNode) {
             const index = this.modelState.index;
+
             index.getIncomingEdges(nodeToDelete).forEach(incoming => {
-                this.collectDependents(dependents, incoming);
+                dependents.add(incoming);
             });
             index.getOutgoingEdges(nodeToDelete).forEach(outgoing => {
-                this.collectDependents(dependents, outgoing);
+                dependents.add(outgoing);
             });
         }
 


### PR DESCRIPTION
- Fix cut operation handler Ensure that the GModelCutOperation handler does not execute a command itself and instead dispatches a corresponding DeleteOperation
- Fix dependecy resolvement in delete-operaetion handler