### PR TITLE
Ensure async usage of JsonOperationHandler.commandOf

### DIFF
--- a/packages/server/src/common/operations/json-operation-handler.ts
+++ b/packages/server/src/common/operations/json-operation-handler.ts
@@ -55,7 +55,10 @@ export namespace JsonModelState {
  * to the `sourceModel` of the given {@link JsonModelState} during the given `doExecute` function
  */
 export class JsonRecordingCommand<JsonObject extends AnyObject = AnyObject> extends AbstractRecordingCommand<JsonObject> {
-    constructor(protected modelState: JsonModelState<JsonObject>, protected doExecute: () => MaybePromise<void>) {
+    constructor(
+        protected modelState: JsonModelState<JsonObject>,
+        protected doExecute: () => MaybePromise<void>
+    ) {
         super();
     }
 
@@ -75,7 +78,7 @@ export class JsonRecordingCommand<JsonObject extends AnyObject = AnyObject> exte
  */
 @injectable()
 export abstract class JsonOperationHandler extends OperationHandler {
-    protected commandOf(runnable: () => void): Command {
+    protected commandOf(runnable: () => MaybePromise<void>): Command {
         if (!JsonModelState.is(this.modelState)) {
             throw new Error('Cannot create command. The underlying model state does not implement the `JsonModelState` interface');
         }
@@ -99,8 +102,10 @@ export abstract class JsonCreateNodeOperationHandler extends JsonOperationHandle
     }
 
     protected createTriggerNodeCreationAction(elementTypeId: string): TriggerNodeCreationAction {
-        return TriggerNodeCreationAction.create(elementTypeId,
-            { ghostElement: this.createTriggerGhostElement(elementTypeId), args: this.createTriggerArgs(elementTypeId) } );
+        return TriggerNodeCreationAction.create(elementTypeId, {
+            ghostElement: this.createTriggerGhostElement(elementTypeId),
+            args: this.createTriggerArgs(elementTypeId)
+        });
     }
 
     protected createTriggerGhostElement(elementTypeId: string): GhostElement | undefined {


### PR DESCRIPTION
Make runnable of command return a MaybePromise to be consistent with the doExecute method of recording commands and support async recordings.