### PR TITLE
GLSP-1227: Ensure that model update is correct when using autolayout

### DIFF
--- a/packages/server/src/common/features/model/model-submission-handler.ts
+++ b/packages/server/src/common/features/model/model-submission-handler.ts
@@ -133,11 +133,12 @@ export class ModelSubmissionHandler {
      * @returns A list of actions to be processed in order to submit the model.
      */
     async submitModelDirectly(reason?: DirtyStateChangeReason): Promise<Action[]> {
-        const root = this.serializeGModel();
-
         if (this.diagramConfiguration.layoutKind === ServerLayoutKind.AUTOMATIC && this.layoutEngine) {
             await this.layoutEngine.layout();
         }
+
+        const root = this.serializeGModel();
+
         const result: Action[] = [];
         result.push(
             this.requestModelAction


### PR DESCRIPTION
In the `submmitModelDirectly` method of the `ModelSubmissionHandler` the gmodel serialization was invoked before the layout engine was executed (in automatic layouting mode). As a consequence the model sent to the server reflected the unlayouted state.

Fixes https://github.com/eclipse-glsp/glsp/issues/1227