### PR TITLE
GLSP-1266 Fix handling of zero values in builder functions

### DIFF
--- a/packages/graph/src/galignable.spec.ts
+++ b/packages/graph/src/galignable.spec.ts
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { DefaultTypes } from '@eclipse-glsp/protocol';
+import { expect } from 'chai';
+import { GAlignableBuilder, isGAlignable } from './galignable';
+import { GLabel, GLabelBuilder } from './glabel';
+import { GNode, GNodeBuilder } from './gnode';
+
+describe('GAlignable Tests', () => {
+    describe('isGAlignable function', () => {
+        it('should return true for a GAlignable element', () => {
+            const gLabelElement = new GLabelBuilder(GLabel) //
+                .type(DefaultTypes.LABEL) //
+                .build();
+
+            const result = isGAlignable(gLabelElement);
+            expect(result).to.be.true;
+        });
+
+        it('should return false for a non-GAlignable element', () => {
+            const gNodeElement = new GNodeBuilder(GNode) //
+                .position(100, 50) //
+                .size(50, 15) //
+                .type(DefaultTypes.NODE) //
+                .build();
+
+            const result = isGAlignable(gNodeElement);
+            expect(result).to.be.false;
+        });
+    });
+
+    describe('GAlignableBuilder alignment function', () => {
+        it('should set alignment using a point object', () => {
+            const builder = new GLabelBuilder(GLabel);
+            GAlignableBuilder.alignment(builder, { x: 45, y: 90 });
+            expect(builder['proxy'].alignment).to.deep.equal({ x: 45, y: 90 });
+        });
+
+        it('should set alignment using x and y parameters', () => {
+            let builder = new GLabelBuilder(GLabel);
+            GAlignableBuilder.alignment(builder, 8, 16);
+            expect(builder['proxy'].alignment).to.deep.equal({ x: 8, y: 16 });
+
+            builder = new GLabelBuilder(GLabel);
+            GAlignableBuilder.alignment(builder, 12, 0);
+            expect(builder['proxy'].alignment).to.deep.equal({ x: 12, y: 0 });
+        });
+
+        it('should set alignment from point object if y is provided too', () => {
+            const builder = new GLabelBuilder(GLabel);
+            GAlignableBuilder.alignment(builder, { x: 17, y: 71 }, 15);
+            expect(builder['proxy'].alignment).to.deep.equal({ x: 17, y: 71 });
+        });
+
+        it('should default y to 0 if y is not provided', () => {
+            const builder = new GLabelBuilder(GLabel);
+            GAlignableBuilder.alignment(builder, 77);
+            expect(builder['proxy'].alignment).to.deep.equal({ x: 77, y: 0 });
+        });
+    });
+});

--- a/packages/graph/src/galignable.ts
+++ b/packages/graph/src/galignable.ts
@@ -34,8 +34,14 @@ export namespace GAlignableBuilder {
         const proxy = builder['proxy'];
         if (typeof pointOrX === 'object') {
             proxy.alignment = pointOrX;
-        } else if (y) {
+        } else if (y !== undefined) {
             proxy.alignment = { x: pointOrX, y };
+        } else {
+            // Optionally handle cases where y is not provided
+            proxy.alignment = { x: pointOrX, y: 0 };
+            console.warn(
+                `Incomplete parameters for GAlignableBuilder.alignment function. Setting alignment to ${JSON.stringify(proxy.alignment)}`
+            );
         }
         return builder;
     }

--- a/packages/graph/src/gbounds-aware.spec.ts
+++ b/packages/graph/src/gbounds-aware.spec.ts
@@ -1,0 +1,105 @@
+/********************************************************************************
+ * Copyright (c) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { DefaultTypes } from '@eclipse-glsp/protocol';
+import { expect } from 'chai';
+import { GBoundsAwareBuilder, isGBoundsAware } from './gbounds-aware';
+import { GEdge, GEdgeBuilder } from './gedge';
+import { GNode, GNodeBuilder } from './gnode';
+import { GShapeElementBuilder } from './gshape-element';
+
+describe('GBoundsAware Tests', () => {
+    describe('isGBoundsAware function', () => {
+        it('should return true for a GBoundsAware element', () => {
+            const gNodeElement = new GNodeBuilder(GNode) //
+                .position(100, 50) //
+                .size(50, 15) //
+                .type(DefaultTypes.NODE) //
+                .build();
+
+            const result = isGBoundsAware(gNodeElement);
+            expect(result).to.be.true;
+        });
+
+        it('should return false for a non-GBoundsAware element', () => {
+            const gEdgeElement = new GEdgeBuilder(GEdge) //
+                .type(DefaultTypes.EDGE) //
+                .build();
+
+            const result = isGBoundsAware(gEdgeElement);
+            expect(result).to.be.false;
+        });
+    });
+
+    describe('GBoundsAwareBuilder position function', () => {
+        it('should set position using a point object', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.position(builder, { x: 5, y: 10 });
+            expect(builder['proxy'].position).to.deep.equal({ x: 5, y: 10 });
+        });
+
+        it('should set position using x and y parameters', () => {
+            let builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.position(builder, 5, 10);
+            expect(builder['proxy'].position).to.deep.equal({ x: 5, y: 10 });
+
+            builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.position(builder, 5, 0);
+            expect(builder['proxy'].position).to.deep.equal({ x: 5, y: 0 });
+        });
+
+        it('should set position from point object if y is provided too', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.position(builder, { x: 17, y: 71 }, 15);
+            expect(builder['proxy'].position).to.deep.equal({ x: 17, y: 71 });
+        });
+
+        it('should default y to 0 if y is not provided', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.position(builder, 35);
+            expect(builder['proxy'].position).to.deep.equal({ x: 35, y: 0 });
+        });
+    });
+
+    describe('GBoundsAwareBuilder size function', () => {
+        it('should set size using a dimension object', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.size(builder, { width: 55, height: 15 });
+            expect(builder['proxy'].size).to.deep.equal({ width: 55, height: 15 });
+        });
+
+        it('should set size using width and height parameters', () => {
+            let builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.size(builder, 50, 35);
+            expect(builder['proxy'].size).to.deep.equal({ width: 50, height: 35 });
+
+            builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.size(builder, 70, 0);
+            expect(builder['proxy'].size).to.deep.equal({ width: 70, height: 0 });
+        });
+
+        it('should set size from dimension object if height is provided too', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.size(builder, { width: 11, height: 33 }, 15);
+            expect(builder['proxy'].size).to.deep.equal({ width: 11, height: 33 });
+        });
+
+        it('should default height to 0 if height is not provided', () => {
+            const builder = new GShapeElementBuilder(GNode);
+            GBoundsAwareBuilder.size(builder, 60);
+            expect(builder['proxy'].size).to.deep.equal({ width: 60, height: 0 });
+        });
+    });
+});

--- a/packages/graph/src/gbounds-aware.ts
+++ b/packages/graph/src/gbounds-aware.ts
@@ -35,8 +35,14 @@ export namespace GBoundsAwareBuilder {
         const proxy = builder['proxy'];
         if (typeof pointOrX === 'object') {
             proxy.position = pointOrX;
-        } else if (y) {
+        } else if (y !== undefined) {
             proxy.position = { x: pointOrX, y };
+        } else {
+            // Optionally handle cases where y is not provided
+            proxy.position = { x: pointOrX, y: 0 };
+            console.warn(
+                `Incomplete parameters for GBoundsAwareBuilder.position function. Setting position to ${JSON.stringify(proxy.position)}`
+            );
         }
         return builder;
     }
@@ -45,8 +51,12 @@ export namespace GBoundsAwareBuilder {
         const proxy = builder['proxy'];
         if (typeof sizeOrWidth === 'object') {
             proxy.size = sizeOrWidth;
-        } else if (height) {
+        } else if (height !== undefined) {
             proxy.size = { width: sizeOrWidth, height };
+        } else {
+            // Optionally handle cases where height is not provided
+            proxy.size = { width: sizeOrWidth, height: 0 };
+            console.warn(`Incomplete parameters for GBoundsAwareBuilder.size function. Setting size to ${JSON.stringify(proxy.size)}`);
         }
         return builder;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Fix handling of zero values in `GBoundsAwareBuilder` functions
- Fix handling of zero values in `GAlignableBuilder` function
- Adds unit tests for those updated functions

Resolves eclipse-glsp/glsp/issues/1266

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
