### PR TITLE
Fixed webworker startup bc elkjs hidden dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ report.xml
 
 wf-glsp-server-node.js
 wf-glsp-server-node.js.map
+wf-glsp-server-webworker.js
+wf-glsp-server-webworker.js.map

--- a/examples/workflow-server-bundled/package.json
+++ b/examples/workflow-server-bundled/package.json
@@ -41,7 +41,7 @@
     "wf-glsp-server-node.js.map"
   ],
   "scripts": {
-    "clean": "rimraf wf-glsp-server-node.js wf-glsp-server-node.js.map",
+    "clean": "rimraf wf-glsp-server-node.js wf-glsp-server-node.js.map wf-glsp-server-webworker.js wf-glsp-server-webworker.js.map",
     "start": "node --enable-source-maps ./wf-glsp-server-node.js --port 5007",
     "start:websocket": "node --enable-source-maps ./wf-glsp-server-node.js -w --port 8081",
     "watch": "tsc -w"

--- a/packages/layout-elk/src/di.config.ts
+++ b/packages/layout-elk/src/di.config.ts
@@ -82,7 +82,11 @@ export function configureELKLayoutModule(options: ElkModuleOptions): ContainerMo
         const elkFactory: ElkFactory = () =>
             new ElkConstructor({
                 algorithms: options.algorithms,
-                defaultLayoutOptions: options.defaultLayoutOptions
+                defaultLayoutOptions: options.defaultLayoutOptions,
+                // The node implementation relied on elkjs' `FakeWorker` to set the `workerFactory`.
+                // However, since the required file is dynamically loaded and not available in a web-worker context,
+                // it needs to be mocked manually.
+                workerFactory: () => ({ postMessage: () => {} }) as unknown as Worker
             });
 
         bind(ElkFactory).toConstantValue(elkFactory);


### PR DESCRIPTION
As described in the comment, but `elkjs` wants to instantiate workers. If no `workerFactory` is given, it tries to resolve this using a fake worker from `elk-worker.min.js`, which is seemingly available when started through node, but not in a web-worker context. Since it is a dynamic import unknown to webpack, it is not bundled.

Therefore, I simply assigned a simple stub, since the worker functionality of `elkjs` is not needed. This enables the server to start in a worker as expected.