### PR TITLE
GLSP-1195: Handle parsing errors in winston logger

### DIFF
--- a/packages/server/src/node/di/winston-logger.ts
+++ b/packages/server/src/node/di/winston-logger.ts
@@ -74,6 +74,10 @@ export class WinstonLogger extends Logger {
             return `${param.message}
             ${param.stack || ''}`;
         }
-        return JSON.stringify(param, undefined, 4);
+        try {
+            return JSON.stringify(param, undefined, 4);
+        } catch (_) {
+            return '';
+        }
     }
 }


### PR DESCRIPTION


Fixes https://github.com/eclipse-glsp/glsp/issues/1195

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Ensure that the WinstonLogger does not throw an error if it encounters an unparseable object (e.g. circular structure)
- Add fallback hooks for uncaught exceptions/promise rejections to example server to avoid nodes default behavior (process exit)

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
