### PR TITLE
Mocked workerFactory only for webworker context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ report.xml
 
 wf-glsp-server-node.js
 wf-glsp-server-node.js.map
+wf-glsp-server-webworker.js
+wf-glsp-server-webworker.js.map

--- a/examples/workflow-server-bundled/package.json
+++ b/examples/workflow-server-bundled/package.json
@@ -41,7 +41,7 @@
     "wf-glsp-server-node.js.map"
   ],
   "scripts": {
-    "clean": "rimraf wf-glsp-server-node.js wf-glsp-server-node.js.map",
+    "clean": "rimraf wf-glsp-server-node.js wf-glsp-server-node.js.map wf-glsp-server-webworker.js wf-glsp-server-webworker.js.map",
     "start": "node --enable-source-maps ./wf-glsp-server-node.js --port 5007",
     "start:websocket": "node --enable-source-maps ./wf-glsp-server-node.js -w --port 8081",
     "watch": "tsc -w"

--- a/examples/workflow-server/src/browser/app.ts
+++ b/examples/workflow-server/src/browser/app.ts
@@ -27,7 +27,11 @@ export async function launch(argv?: string[]): Promise<void> {
     appContainer.load(createAppModule({ logLevel: LogLevel.info }));
 
     const launcher = appContainer.resolve(WorkerServerLauncher);
-    const elkLayoutModule = configureELKLayoutModule({ algorithms: ['layered'], layoutConfigurator: WorkflowLayoutConfigurator });
+    const elkLayoutModule = configureELKLayoutModule({
+        algorithms: ['layered'],
+        layoutConfigurator: WorkflowLayoutConfigurator,
+        isWebWorker: true
+    });
 
     const serverModule = new WorkflowServerModule().configureDiagramModule(
         new WorkflowDiagramModule(() => WorkflowMockModelStorage),

--- a/packages/layout-elk/src/di.config.ts
+++ b/packages/layout-elk/src/di.config.ts
@@ -45,6 +45,11 @@ export interface ElkModuleOptions {
      * is bound.
      */
     elementFilter?: Constructor<ElementFilter>;
+    /**
+     * A flag to indicate whether a WebWorker context is provided. If this option is set, a feature is mocked that would
+     * only be available in a node environment.
+     */
+    isWebWorker?: boolean;
 }
 
 /**
@@ -82,7 +87,11 @@ export function configureELKLayoutModule(options: ElkModuleOptions): ContainerMo
         const elkFactory: ElkFactory = () =>
             new ElkConstructor({
                 algorithms: options.algorithms,
-                defaultLayoutOptions: options.defaultLayoutOptions
+                defaultLayoutOptions: options.defaultLayoutOptions,
+                // The node implementation relied on elkjs' `FakeWorker` to set the `workerFactory`.
+                // However, since the required file is dynamically loaded and not available in a web-worker context,
+                // it needs to be mocked manually.
+                workerFactory: options.isWebWorker ? () => ({ postMessage: () => {} }) as unknown as Worker : undefined
             });
 
         bind(ElkFactory).toConstantValue(elkFactory);


### PR DESCRIPTION
As requested in #78, the change is now restricted to browser/web-worker context.