### PR TITLE
Configure fork and join nodes as not resizable

### DIFF
--- a/examples/workflow-server/src/common/workflow-diagram-configuration.ts
+++ b/examples/workflow-server/src/common/workflow-diagram-configuration.ts
@@ -48,33 +48,26 @@ export class WorkflowDiagramConfiguration implements DiagramConfiguration {
         return [
             createDefaultShapeTypeHint(types.MANUAL_TASK),
             createDefaultShapeTypeHint(types.AUTOMATED_TASK),
-            createDefaultShapeTypeHint(types.FORK_NODE),
-            createDefaultShapeTypeHint(types.JOIN_NODE),
+            createDefaultShapeTypeHint({ elementTypeId: types.FORK_NODE, resizable: false }),
+            createDefaultShapeTypeHint({ elementTypeId: types.JOIN_NODE, resizable: false }),
             createDefaultShapeTypeHint(types.DECISION_NODE),
             createDefaultShapeTypeHint(types.MERGE_NODE),
-            {
+            createDefaultShapeTypeHint({
                 elementTypeId: types.CATEGORY,
-                repositionable: true,
-                deletable: true,
-                resizable: true,
-                reparentable: true,
                 containableElementTypeIds: [types.TASK, types.ACTIVITY_NODE, types.CATEGORY]
-            }
+            })
         ];
     }
 
     get edgeTypeHints(): EdgeTypeHint[] {
         return [
             createDefaultEdgeTypeHint(DefaultTypes.EDGE),
-            {
-                elementTypeId: types.WEIGHTED_EDGE,
-                repositionable: true,
-                deletable: true,
-                routable: true,
+            createDefaultEdgeTypeHint({
+                elementTypeId: DefaultTypes.EDGE,
                 dynamic: true,
                 sourceElementTypeIds: [types.ACTIVITY_NODE],
                 targetElementTypeIds: [types.TASK, types.ACTIVITY_NODE]
-            }
+            })
         ];
     }
 
@@ -83,13 +76,20 @@ export class WorkflowDiagramConfiguration implements DiagramConfiguration {
     animatedUpdate = true;
 }
 
-export function createDefaultShapeTypeHint(elementId: string): ShapeTypeHint {
-    return { elementTypeId: elementId, repositionable: true, deletable: true, resizable: true, reparentable: true };
+export function createDefaultShapeTypeHint(template: { elementTypeId: string } & Partial<ShapeTypeHint>): ShapeTypeHint;
+export function createDefaultShapeTypeHint(elementId: string): ShapeTypeHint;
+export function createDefaultShapeTypeHint(
+    elementIdOrTemplate: string | ({ elementTypeId: string } & Partial<ShapeTypeHint>)
+): ShapeTypeHint {
+    const template = typeof elementIdOrTemplate === 'string' ? { elementTypeId: elementIdOrTemplate } : elementIdOrTemplate;
+    return { repositionable: true, deletable: true, resizable: true, reparentable: true, ...template };
 }
 
-export function createDefaultEdgeTypeHint(elementId: string): EdgeTypeHint {
+export function createDefaultEdgeTypeHint(template: { elementTypeId: string } & Partial<EdgeTypeHint>): EdgeTypeHint;
+export function createDefaultEdgeTypeHint(elementId: string): EdgeTypeHint;
+export function createDefaultEdgeTypeHint(elementIdOrTemplate: string | ({ elementTypeId: string } & Partial<EdgeTypeHint>)): EdgeTypeHint {
+    const template = typeof elementIdOrTemplate === 'string' ? { elementTypeId: elementIdOrTemplate } : elementIdOrTemplate;
     return {
-        elementTypeId: elementId,
         repositionable: true,
         deletable: true,
         routable: true,
@@ -110,6 +110,7 @@ export function createDefaultEdgeTypeHint(elementId: string): EdgeTypeHint {
             types.FORK_NODE,
             types.JOIN_NODE,
             types.CATEGORY
-        ]
+        ],
+        ...template
     };
 }

--- a/examples/workflow-server/src/common/workflow-edge-creation-checker.ts
+++ b/examples/workflow-server/src/common/workflow-edge-creation-checker.ts
@@ -21,7 +21,7 @@ import { ModelTypes } from './util/model-types';
 @injectable()
 export class WorkflowEdgeCreationChecker implements EdgeCreationChecker {
     isValidSource(edgeType: string, sourceElement: GModelElement): boolean {
-        return edgeType !== ModelTypes.WEIGHTED_EDGE || sourceElement.type === ModelTypes.DECISION_NODE;
+        return edgeType !== ModelTypes.WEIGHTED_EDGE && sourceElement.type === ModelTypes.DECISION_NODE;
     }
     isValidTarget(edgeType: string, sourceElement: GModelElement, targetElement: GModelElement): boolean {
         return (


### PR DESCRIPTION


Refactor createDefault hint functions to allow partial overriding of default properties

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Update type hints configuration for workflow example to make fork and join nodes not resizable => we have test cases for both resizable and non-resizable elements in the diagram

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
