### PR TITLE
Minor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 -   [launch] Improve Winston-Logger implementation to properly handle non-serializable objects [#82](https://github.com/eclipse-glsp/glsp-server-node/pull/82)
 -   [layout] Ensure that including `ElkLayoutEngine` engine does not error in browser-only server implementations [#83](https://github.com/eclipse-glsp/glsp-server-node/pull/83)
 -   [gmodel] Introduce new `Resizable` interface that is implemented by all `GShapeElements` and allows per-element definition of resize handle locations [#84](https://github.com/eclipse-glsp/glsp-server-node/pull/84)
+-   [action] Ensure that actions queued with `dispatchAfterNextUpdate` are also dispatched after the initial `SetModelAction` [#88](https://github.com/eclipse-glsp/glsp-server-node/pull/88)
+
+### Potentially Breaking Changes
+
+-   [protocol] Removed local definition of `GIssueMarker` and reuse it from `@eclipse-glsp/protocol` instead [#88](https://github.com/eclipse-glsp/glsp-server-node/pull/88)
+    -   => `GIssueMarker` is now an interface instead of a class
 
 ## [v2.1.0 - 25/01/2024](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v2.1.0)
 

--- a/examples/workflow-server/src/common/workflow-popup-factory.ts
+++ b/examples/workflow-server/src/common/workflow-popup-factory.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -38,7 +38,7 @@ export class WorkflowPopupFactory implements PopupModelFactory {
         return undefined;
     }
 
-    private generateBody(task: TaskNode): string {
+    protected generateBody(task: TaskNode): string {
         return `Type: ${task.taskType} ${NL}
             Duration: ${task.duration} ${NL}
             Reference: ${task.references} ${NL}`;

--- a/packages/graph/src/gedge-layoutable.ts
+++ b/packages/graph/src/gedge-layoutable.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,9 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { EdgeSide } from '@eclipse-glsp/protocol';
 import { GModelElement, GModelElementBuilder } from './gmodel-element';
-
-export type EdgeSide = 'left' | 'right' | 'top' | 'bottom' | 'on';
 
 export interface GEdgePlacement {
     rotate: boolean;

--- a/packages/graph/src/gissue-marker.ts
+++ b/packages/graph/src/gissue-marker.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,15 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { DefaultTypes, flatPush, MaybeArray } from '@eclipse-glsp/protocol';
+import { DefaultTypes, flatPush, GIssue, GIssueSeverity, MaybeArray } from '@eclipse-glsp/protocol';
 import { GShapeElement, GShapeElementBuilder } from './gshape-element';
-
-export type GIssueSeverity = 'error' | 'warning' | 'info';
-
-export class GIssue {
-    message: string;
-    severity: GIssueSeverity;
-}
 
 export class GIssueMarker extends GShapeElement {
     static builder(): GIssueMarkerBuilder {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     "@types/uuid": "8.3.1",
     "commander": "^8.3.0",
     "fast-json-patch": "^3.1.0",
-    "vscode-jsonrpc": "^8.0.2",
+    "vscode-jsonrpc": "8.2.0",
     "winston": "^3.3.3",
     "ws": "^8.12.1"
   },

--- a/packages/server/src/common/actions/action-dispatcher.ts
+++ b/packages/server/src/common/actions/action-dispatcher.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, Disposable, flatPush, MaybeArray, RequestAction, ResponseAction, UpdateModelAction } from '@eclipse-glsp/protocol';
+import {
+    Action,
+    Disposable,
+    MaybeArray,
+    RequestAction,
+    ResponseAction,
+    SetModelAction,
+    UpdateModelAction,
+    flatPush
+} from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import { ClientId } from '../di/service-identifiers';
 import { GLSPServerError } from '../utils/glsp-server-error';
@@ -67,7 +76,7 @@ export class DefaultActionDispatcher implements ActionDispatcher, Disposable {
     protected clientActionForwarder: ClientActionForwarder;
 
     @inject(Logger)
-    private logger: Logger;
+    protected logger: Logger;
 
     @inject(ClientId)
     protected clientId: string;
@@ -98,7 +107,7 @@ export class DefaultActionDispatcher implements ActionDispatcher, Disposable {
             responses.push(...response);
         }
 
-        if (UpdateModelAction.is(action) && this.postUpdateQueue.length > 0) {
+        if (this.postUpdateQueue.length > 0 && (UpdateModelAction.is(action) || SetModelAction.is(action))) {
             responses.push(...this.postUpdateQueue);
             this.postUpdateQueue = [];
         }

--- a/packages/server/src/common/features/model/request-model-action-handler.ts
+++ b/packages/server/src/common/features/model/request-model-action-handler.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,7 +29,7 @@ export class RequestModelActionHandler implements ActionHandler {
     actionKinds = [RequestModelAction.KIND];
 
     @inject(Logger)
-    private logger: Logger;
+    protected logger: Logger;
 
     @inject(SourceModelStorage)
     protected sourceModelStorage: SourceModelStorage;

--- a/packages/server/src/common/utils/client-options-util.ts
+++ b/packages/server/src/common/utils/client-options-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,7 +17,7 @@ import { Args } from '@eclipse-glsp/protocol';
 import { ArgsUtil } from './args-util';
 
 export class ClientOptionsUtil {
-    private static FILE_PREFIX = 'file://';
+    public static FILE_PREFIX = 'file://';
     public static IS_RECONNECTING = 'isReconnecting';
 
     public static adaptUri(uri: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,13 +310,13 @@
     prettier-plugin-packagejson "~2.4.6"
 
 "@eclipse-glsp/protocol@next":
-  version "2.2.0-next.345"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0-next.345.tgz#7e3f3aa6ca8af74b54d147823b4c2ae4c3c868e3"
-  integrity sha512-EDwEWoYZuMP33mCV+4XP5f6154gbpQv8TJwpzq5kS4Fq0P5+AYXDmjdYtB2HCHo1EiFyRlNFhMSQVuPDLTfoHA==
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0-next.353.tgz#5effcb22dd25ffae5a7264324c2752cf89754629"
+  integrity sha512-LARvLG1bEmmfR8e6wFoEyYwOfMiQMyHEi/2SD/c08BUIDjEAuxbUEQyx2g+d9btfHdVEZJXfwfvy5oIuLEuI1Q==
   dependencies:
-    sprotty-protocol "1.0.0"
-    uuid "7.0.3"
-    vscode-jsonrpc "^8.0.2"
+    sprotty-protocol "1.2.0"
+    uuid "~10.0.0"
+    vscode-jsonrpc "8.2.0"
 
 "@eclipse-glsp/ts-config@2.2.0-next.c32aadb.160+c32aadb":
   version "2.2.0-next.c32aadb.160"
@@ -6725,10 +6725,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sprotty-protocol@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-1.0.0.tgz#b22e2da7e10b168debdc17feb61c4b832f01f614"
-  integrity sha512-p1H+ihcOmj0LEk2atcwOnYQPm0WByaOB1yX7fd869ONfQ5R+7x0X20YPdVLeCWmnhsszC/Rf91ojwaQiNIiHNA==
+sprotty-protocol@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-1.2.0.tgz#cfd6d637f2670a3d641997bb5add27cb1bddb57a"
+  integrity sha512-SHu61Qiw7bAD2nyRqdOASSihVNbeEuKI7cQx+o9EeyLpbmXKX6NTcGSVpxmWztHUIP0I6gZhKnkhF/BWo46mUQ==
 
 ssri@^10.0.0, ssri@^10.0.1:
   version "10.0.6"
@@ -7408,11 +7408,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
 uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -7427,6 +7422,11 @@ uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uuid@~10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -7465,7 +7465,7 @@ validate-npm-package-name@^5.0.0:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
-vscode-jsonrpc@^8.0.2:
+vscode-jsonrpc@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
   integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==


### PR DESCRIPTION
- Change visibility of private fields to protected for better extensibility
- Update to latest protocol version
  - This introduces a minor unavoidable API break because GIssue has changed from a class to an interface definition
- Ensure that actions queued with `dispatchAfterNextUpdate` are also dispatched after the initial `SetModelAction`
- Fix copyright header violations

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
