### PR TITLE
Fix workflow documentation navigation example

### DIFF
--- a/examples/workflow-server/src/common/provider/node-documentation-navigation-target-provider.ts
+++ b/examples/workflow-server/src/common/provider/node-documentation-navigation-target-provider.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { Args, EditorContext, NavigationTarget } from '@eclipse-glsp/protocol';
-import { JsonOpenerOptions, ModelState, NavigationTargetProvider } from '@eclipse-glsp/server';
+import { GLabel, JsonOpenerOptions, ModelState, NavigationTargetProvider } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { TaskNode } from '../graph-extension';
 
@@ -28,7 +28,7 @@ export class NodeDocumentationNavigationTargetProvider implements NavigationTarg
     getTargets(editorContext: EditorContext): NavigationTarget[] {
         if (editorContext.selectedElementIds.length === 1) {
             const taskNode = this.modelState.index.findByClass(editorContext.selectedElementIds[0], TaskNode);
-            if (!taskNode || !(taskNode.id === 'task0')) {
+            if (!taskNode || !taskNode.children.some(child => child instanceof GLabel && child.text === 'Push')) {
                 return [];
             }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Update the NodeDocumentationNavigationTargetProvider to not rely on the tasks name which is currently unreliable (see https://github.com/eclipse-glsp/glsp/issues/1351) and instead relies on the `text` property of the tasks label.

<!-- Include relevant issues and describe how they are addressed. -->
Fix workflow documentation navigation example
#### How to test
- Build and start
- Connect the Theia or vscode integration example (by starting in debug mode)
- Verify that Go to documentation on the "push" node works)
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
