### PR TITLE
Revert "V2.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Server Changelog
 
-## [v2.2.0- 04/07/2024](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v2.2.0)
+## v2.2.0- active
 
 -   [layout] Ensure that model is updated correctly when using `automatic` server layout [#74](https://github.com/eclipse-glsp/glsp-server-node/pull/74)
 -   [gmodel] Add proper undefined/null handling in GModel builder functions [#76](https://github.com/eclipse-glsp/glsp-server-node/pull/76)

--- a/examples/workflow-server-bundled/package.json
+++ b/examples/workflow-server-bundled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server-bundled",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "GLSP node server for the workflow example (bundled)",
   "keywords": [
     "eclipse",

--- a/examples/workflow-server/package.json
+++ b/examples/workflow-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "GLSP node server for the workflow example",
   "keywords": [
     "eclipse",
@@ -56,9 +56,9 @@
     "watch:bundle": "webpack -w"
   },
   "dependencies": {
-    "@eclipse-glsp/layout-elk": "2.2.0",
-    "@eclipse-glsp/server": "2.2.0",
-    "inversify": "^6.0.2"
+    "@eclipse-glsp/layout-elk": "2.2.0-next",
+    "@eclipse-glsp/server": "2.2.0-next",
+    "inversify": "^6.0.1"
   },
   "devDependencies": {
     "source-map-loader": "^4.0.1",

--- a/examples/workflow-server/src/common/provider/node-documentation-navigation-target-provider.ts
+++ b/examples/workflow-server/src/common/provider/node-documentation-navigation-target-provider.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 STMicroelectronics and others.
+ * Copyright (c) 2022-2023 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/examples/workflow-server/src/common/workflow-popup-factory.ts
+++ b/examples/workflow-server/src/common/workflow-popup-factory.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.1.0",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -33,7 +33,7 @@
     "watch:bundle": "yarn --cwd examples/workflow-server watch:bundle"
   },
   "devDependencies": {
-    "@eclipse-glsp/dev": "2.2.0",
+    "@eclipse-glsp/dev": "next",
     "@types/node": "16.x",
     "concurrently": "^8.2.2",
     "lerna": "^7.0.0",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/graph",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "The typescript implementation of the GLSP graphical model (GModel)",
   "keywords": [
     "eclipse",
@@ -49,7 +49,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/protocol": "2.2.0"
+    "@eclipse-glsp/protocol": "next"
   },
   "devDependencies": {
     "@types/uuid": "8.3.1"

--- a/packages/graph/src/gedge-layoutable.ts
+++ b/packages/graph/src/gedge-layoutable.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/layout-elk/package.json
+++ b/packages/layout-elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/layout-elk",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "Integration of ELK graph layout algorithms in GLSP Node Server",
   "keywords": [
     "eclipse",
@@ -49,7 +49,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/server": "2.2.0",
+    "@eclipse-glsp/server": "2.2.0-next",
     "elkjs": "^0.7.1"
   },
   "peerDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/server",
-  "version": "2.2.0",
+  "version": "2.2.0-next",
   "description": "A js server framework for Eclipse GLSP",
   "keywords": [
     "eclipse",
@@ -58,8 +58,8 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/graph": "2.2.0",
-    "@eclipse-glsp/protocol": "2.2.0",
+    "@eclipse-glsp/graph": "2.2.0-next",
+    "@eclipse-glsp/protocol": "next",
     "@types/uuid": "8.3.1",
     "commander": "^8.3.0",
     "fast-json-patch": "^3.1.0",

--- a/packages/server/src/common/actions/action-dispatcher.ts
+++ b/packages/server/src/common/actions/action-dispatcher.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/server/src/common/features/model/request-model-action-handler.ts
+++ b/packages/server/src/common/features/model/request-model-action-handler.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/server/src/common/utils/client-options-util.ts
+++ b/packages/server/src/common/utils/client-options-util.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2024 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp/cli@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0.tgz#1f9659c2ee05739d167f1c40ab79c689e56967d6"
-  integrity sha512-bR/Wb3cvJRA1LcghYEJAG9PB3Dc4NLYrl75lCmjsyWzl8RXoxKfTTCgFoCmFRZdxtkufMr3kQZirnRCyjeVl6w==
+"@eclipse-glsp/cli@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/cli/-/cli-2.2.0-next.c32aadb.160.tgz#1171b21aec7bddfcc73e68cc41d0b9dcb199c258"
+  integrity sha512-Clw0YKkMg41vQnd3UY9quIConKdQoQ98+dp15ouKps5yG8l3xpmjCC44V10N4LJ5l2Jmol6UTJfPGmA9FyrGdw==
   dependencies:
     commander "^10.0.1"
     glob "^10.3.10"
@@ -237,13 +237,13 @@
     semver "^7.5.1"
     shelljs "^0.8.5"
 
-"@eclipse-glsp/config-test@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0.tgz#a4e108463a98ee5be2946682ff2624f36a073ce1"
-  integrity sha512-rRzZUNsT8p9vkGWqfaHNZg+4x7oIYfMfPP40BUx4lktch+riETkGdsdtecWs9K8TYOLx+SWSaq6hfyZl3832Dw==
+"@eclipse-glsp/config-test@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config-test/-/config-test-2.2.0-next.c32aadb.160.tgz#30f409221024544604f5030caf092ac89d22867d"
+  integrity sha512-STBp0y+SmvpWz+D8wdyiVMelE7jFAGVxicFekalmoNaDO3pUSR3QmuxGHsSwWQ3qOB30vic4eMc3rSMrR4dABw==
   dependencies:
-    "@eclipse-glsp/mocha-config" "2.2.0"
-    "@eclipse-glsp/nyc-config" "2.2.0"
+    "@eclipse-glsp/mocha-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/nyc-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@istanbuljs/nyc-config-typescript" "^1.0.2"
     "@types/chai" "^4.3.7"
     "@types/mocha" "^10.0.2"
@@ -257,14 +257,14 @@
     sinon "^15.1.0"
     ts-node "^10.9.1"
 
-"@eclipse-glsp/config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0.tgz#a55d7bd482e749e036ea4806aa3b6c3bf34a6225"
-  integrity sha512-tEPoYKxlL/8gSoS4B16H51JqzHGhdvDGvhOvu/iefwcuOGM7ZVSR4YzJjSFZjDQfsMPXtKXKFZqT2lizD283iA==
+"@eclipse-glsp/config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-2.2.0-next.c32aadb.160.tgz#5e0c25ef98f2aad44de9cb3de1cb8c2523543835"
+  integrity sha512-rFpykLbc3VC+Nx9iR5dOQUGU9FXYOrxC8qnOOBt+ou+xkSvdDTUYHKC4QKmXRZbiVnhfpbj7CIauBoU2XxineA==
   dependencies:
-    "@eclipse-glsp/eslint-config" "2.2.0"
-    "@eclipse-glsp/prettier-config" "2.2.0"
-    "@eclipse-glsp/ts-config" "2.2.0"
+    "@eclipse-glsp/eslint-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/prettier-config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/ts-config" "2.2.0-next.c32aadb.160+c32aadb"
     "@typescript-eslint/eslint-plugin" "^6.7.5"
     "@typescript-eslint/parser" "^6.7.5"
     eslint "^8.51.0"
@@ -278,50 +278,50 @@
     reflect-metadata "^0.1.13"
     rimraf "^5.0.5"
 
-"@eclipse-glsp/dev@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0.tgz#cf745fe50c58a2036da07c92880f23a2336cdc7c"
-  integrity sha512-xXDHdS15ADqvc9iWoPlM78qNUKrVUyMAeiBOZHKcbMWNdqx6kg8w3oUNAmm2C896T8KHrdSLP5meGS2KChjY+g==
+"@eclipse-glsp/dev@next":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/dev/-/dev-2.2.0-next.c32aadb.160.tgz#d67cdceed91cb779e9495d06b6b4c7106541bc4f"
+  integrity sha512-ns0jJBxcW3qkzx8RV8JB/YYHOrK/9OXy7qrvhNabqAPRTpzn5ovp2kv7rZd97JGMPenq+2iSgbcY39eqq4zAHg==
   dependencies:
-    "@eclipse-glsp/cli" "2.2.0"
-    "@eclipse-glsp/config" "2.2.0"
-    "@eclipse-glsp/config-test" "2.2.0"
+    "@eclipse-glsp/cli" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config" "2.2.0-next.c32aadb.160+c32aadb"
+    "@eclipse-glsp/config-test" "2.2.0-next.c32aadb.160+c32aadb"
 
-"@eclipse-glsp/eslint-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0.tgz#c98deff84bf2b7c368fd1d1ed6d232037fc1cf06"
-  integrity sha512-3zbBM3su+iKLwxHoTML6N3/y3MxRtQmDgxyNu4sR9LbBLZshiqd4kUeLFCAzFSznwe+5btbRabClv8pR33FTNQ==
+"@eclipse-glsp/eslint-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.2.0-next.c32aadb.160.tgz#40a2f916d662b5bd5eefac469214b2e74ba8d28c"
+  integrity sha512-BDYLSB9lkgGmwA2fPB8OjnZTD4r48AHWAYSwkFdy/1RwJxL/F8fWlfWu6c8o5AVuNyMkrqedtmfdehSZA01u7A==
 
-"@eclipse-glsp/mocha-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0.tgz#77ab2664ea978db3400c0669ab5114417c1814e0"
-  integrity sha512-Vr9wEuYsTdV7ES0+G43yzSdZzpWn738W8LjSPySjpnrTHVABAB7b3Ba9ITd74Y/pdQXsL+6R47dEV1yoSIu/9A==
+"@eclipse-glsp/mocha-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/mocha-config/-/mocha-config-2.2.0-next.c32aadb.160.tgz#c440d499ced653d342dcb39c52944e03b879ec40"
+  integrity sha512-n3T212zAl5oKMGQM1V8L/GvDsZwyIDdZAVh25yHjh0hFgVfraaGqzvGPTZxlKmJBuD0++6LH9FDhUNcNhMllHQ==
 
-"@eclipse-glsp/nyc-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0.tgz#3f62f6a1c13931b88ebe916d29eda6b2d9c58895"
-  integrity sha512-msBjz00ytdrAigloUtrJBY1pHm2Ugkeqi3ccJrkgxM164YZ/9iQrKCV0iUy9SoydbYCVFF0EtA4aH1jHVIrsbg==
+"@eclipse-glsp/nyc-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/nyc-config/-/nyc-config-2.2.0-next.c32aadb.160.tgz#9f84da72015c90aa2beb1394e14643f353a16158"
+  integrity sha512-m00F5RLly63TNDe76pW2yk/BLGKWpoD+qvga7ZSVDf2KPpdjf2cBjw2ei816H+Avl1TI+ufauQO8NdRu5O5Vuw==
 
-"@eclipse-glsp/prettier-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0.tgz#76c686ea5f829d54f9cccc4d73eb097efe721dba"
-  integrity sha512-5FozTM0xUe0E/k2bqz1D0lPj4waAQyttSMmKIpNH1GwG8eS6lveAtPOuxhCNCR4vNCmhCDtazy+lCGmaKmlJcA==
+"@eclipse-glsp/prettier-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-2.2.0-next.c32aadb.160.tgz#c4e019dbbafd04483cc7916f25c8b3a151f7d916"
+  integrity sha512-xqfSe+UMS4p5WGimZnX5iIm1AX+x1CAAippobgogGRnbA5RBsUdOh/odFgfRcme6/IfyFWj5m4IY7IHlFPZwCw==
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/protocol@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0.tgz#a34d867e28b7f0708fa1d9ec349f650f0e1d427d"
-  integrity sha512-StoA5KqIgvknHkTYKj3+fQjRnuDzp0uhpkH6GOLvHteae0lekXeBYFLfA1pmyIMKycvCOq3k8+wG6tYJR8Q+Uw==
+"@eclipse-glsp/protocol@next":
+  version "2.2.0-next.353"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.2.0-next.353.tgz#5effcb22dd25ffae5a7264324c2752cf89754629"
+  integrity sha512-LARvLG1bEmmfR8e6wFoEyYwOfMiQMyHEi/2SD/c08BUIDjEAuxbUEQyx2g+d9btfHdVEZJXfwfvy5oIuLEuI1Q==
   dependencies:
     sprotty-protocol "1.2.0"
     uuid "~10.0.0"
     vscode-jsonrpc "8.2.0"
 
-"@eclipse-glsp/ts-config@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0.tgz#f08b683e9cc265280cd037965e35824b9a2df709"
-  integrity sha512-U2eD3kdKICK7OQXObLeMsrd80o+eHSIjss0HiUZjF7NQxsrNX9p04rJjEpO4HPrInUQPmpxsw3HVwk3mgo1mew==
+"@eclipse-glsp/ts-config@2.2.0-next.c32aadb.160+c32aadb":
+  version "2.2.0-next.c32aadb.160"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-2.2.0-next.c32aadb.160.tgz#d660cd736056a91c0c79fb2076835073ad12d7b9"
+  integrity sha512-05D85X5tUY/M23rTDs1b9MfF+YbV7j97rTFss5PHad7YI2DOByqMGRxaoPI+xzyoQUUAHTxKekGb5KbE8douDQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -3984,7 +3984,7 @@ interpret@^3.1.1:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
   integrity sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==
 
-inversify@^6.0.2:
+inversify@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.2.tgz#dc7fa0348213d789d35ffb719dea9685570989c7"
   integrity sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==


### PR DESCRIPTION
Reverts eclipse-glsp/glsp-server-node#91
Due to a bug discovered during the release process its necessary to revert the currently ongoing 2.2.0 release.
Already published artifacts will be removed/ unpublished
and a clean 2.2.1 release will be published