### PR TITLE
GLSP-1369 Fix wrong edge type hint

### DIFF
--- a/examples/workflow-server/src/common/workflow-diagram-configuration.ts
+++ b/examples/workflow-server/src/common/workflow-diagram-configuration.ts
@@ -63,7 +63,7 @@ export class WorkflowDiagramConfiguration implements DiagramConfiguration {
         return [
             createDefaultEdgeTypeHint(DefaultTypes.EDGE),
             createDefaultEdgeTypeHint({
-                elementTypeId: DefaultTypes.EDGE,
+                elementTypeId: types.WEIGHTED_EDGE,
                 dynamic: true,
                 sourceElementTypeIds: [types.ACTIVITY_NODE],
                 targetElementTypeIds: [types.TASK, types.ACTIVITY_NODE]


### PR DESCRIPTION

Part of https://github.com/eclipse-glsp/glsp/issues/1369

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Ensure that the type hint for weighted edges if created with the correct `elementTypeId`

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
