### PR TITLE
Ensure JsonrpcClientProxy is injectable in the Node Server context

### DIFF
--- a/packages/server/src/common/reexport.ts
+++ b/packages/server/src/common/reexport.ts
@@ -14,6 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { JsonrpcClientProxy } from '@eclipse-glsp/protocol';
+import { decorate, injectable } from 'inversify';
+
 export * from '@eclipse-glsp/graph';
 export * from '@eclipse-glsp/protocol';
 export * from '@eclipse-glsp/protocol/lib/di';
+decorate(injectable(), JsonrpcClientProxy);

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,9 +310,9 @@
     prettier-plugin-packagejson "~2.4.6"
 
 "@eclipse-glsp/protocol@next":
-  version "2.3.0-next.374"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.3.0-next.374.tgz#9323d1841427f6dbf5fa66dbe1ef3dce4d596b10"
-  integrity sha512-ENZO29yLO7l5asyaDpvkQanGj5jDXGBkvQbZU+D4ULKmvWvDWYle+BBSKMxl7sI6L77tz7kGBLMEhAuhRky4kg==
+  version "2.3.0-next.375"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.3.0-next.375.tgz#b1594533993e7f74d4177314489e7312906e8986"
+  integrity sha512-RoO9/EoeG4NZV8eQZU6L+JVDFuzwx31imHxsdOB3oRdvVhgciFz9NQKjhIQn3M+URABSFsV6QBLSJfFTmfO8yA==
   dependencies:
     sprotty-protocol "1.2.0"
     uuid "~10.0.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Contributed on behalf of Axon Ivy AG
Part of https://github.com/eclipse-glsp/glsp/issues/1381
Requires https://github.com/eclipse-glsp/glsp-client/pull/384

#### How to test

- Everything should still work as expected.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
