### PR TITLE
Fix default type mappings

### DIFF
--- a/packages/graph/src/default-types.ts
+++ b/packages/graph/src/default-types.ts
@@ -17,6 +17,7 @@ import { DefaultTypes as types } from '@eclipse-glsp/protocol';
 import { GButton } from './gbutton';
 import { GCompartment } from './gcompartment';
 import { GEdge } from './gedge';
+import { GForeignObjectElement } from './gforeign-object-element';
 import { GGraph } from './ggraph';
 import { GHtmlRoot } from './ghtml-root';
 import { GIssueMarker } from './gissue-marker';
@@ -43,6 +44,7 @@ export function getDefaultMapping(): Map<string, GModelElementConstructor> {
 
     mapping.set(types.HTML, GHtmlRoot);
     mapping.set(types.PRE_RENDERED, GPreRenderedElement);
-    mapping.set(types.FOREIGN_OBJECT, GShapedPreRenderedElement);
+    mapping.set(types.SHAPE_PRE_RENDERED, GShapedPreRenderedElement);
+    mapping.set(types.FOREIGN_OBJECT, GForeignObjectElement);
     return mapping;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Ensure that the correct type for `foreign-object` is configure and add missing configuration for GShaprePreRenderedElements

Fixes https://github.com/eclipse-glsp/glsp/issues/1398
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
