### PR TITLE
Avoid executing unnecessary operations

### DIFF
--- a/packages/server/src/common/gmodel/change-routing-points-operation-handler.ts
+++ b/packages/server/src/common/gmodel/change-routing-points-operation-handler.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ChangeRoutingPointsOperation, MaybePromise } from '@eclipse-glsp/protocol';
+import { GEdge } from '@eclipse-glsp/graph';
+import { ChangeRoutingPointsOperation, ElementAndRoutingPoints, MaybePromise, Point } from '@eclipse-glsp/protocol';
 import { injectable } from 'inversify';
 import { Command } from '../command/command';
-import { GLSPServerError } from '../utils/glsp-server-error';
 import { applyRoutingPoints } from '../utils/layout-util';
 import { GModelOperationHandler } from './gmodel-operation-handler';
 
@@ -26,14 +26,27 @@ export class GModelChangeRoutingPointsOperationHandler extends GModelOperationHa
     operationType = ChangeRoutingPointsOperation.KIND;
 
     createCommand(operation: ChangeRoutingPointsOperation): MaybePromise<Command | undefined> {
-        return this.commandOf(() => this.executeChangeRoutingPoints(operation));
+        const newRoutingPoints = operation.newRoutingPoints.filter(newRoutingPoints => this.hasChanged(newRoutingPoints));
+        if (newRoutingPoints.length === 0) {
+            return undefined;
+        }
+        return this.commandOf(() => this.executeChangeRoutingPoints({ ...operation, newRoutingPoints }));
+    }
+
+    protected hasChanged(element: ElementAndRoutingPoints): boolean {
+        const knownElement = this.modelState.index.findByClass(element.elementId, GEdge);
+        if (!knownElement || knownElement.routingPoints.length !== element.newRoutingPoints?.length) {
+            return true;
+        }
+        for (let i = 0; i < knownElement.routingPoints.length; i++) {
+            if (!Point.equals(knownElement.routingPoints[i], element.newRoutingPoints[i])) {
+                return true;
+            }
+        }
+        return false;
     }
 
     executeChangeRoutingPoints(operation: ChangeRoutingPointsOperation): MaybePromise<void> {
-        if (!operation.newRoutingPoints) {
-            throw new GLSPServerError('Incomplete change routingPoints  action');
-        }
-
         const index = this.modelState.index;
         operation.newRoutingPoints.forEach(routingPoints => applyRoutingPoints(routingPoints, index));
     }

--- a/packages/server/src/common/operations/compound-operation-handler.ts
+++ b/packages/server/src/common/operations/compound-operation-handler.ts
@@ -40,6 +40,6 @@ export class CompoundOperationHandler extends OperationHandler {
                 commands.push(command);
             }
         }
-        return new CompoundCommand(commands);
+        return commands.length > 0 ? new CompoundCommand(commands) : undefined;
     }
 }

--- a/packages/server/src/common/operations/operation-action-handler.ts
+++ b/packages/server/src/common/operations/operation-action-handler.ts
@@ -67,8 +67,9 @@ export class OperationActionHandler implements ActionHandler {
         const command = await handler.execute(operation);
         if (command) {
             await this.executeCommand(command);
+            return this.submitModel();
         }
-        return this.modelSubmissionHandler.submitModel('operation');
+        return [];
     }
 
     protected async executeCommand(command: Command): Promise<void> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Filter empty change bounds and change routing points operations
- Filter empty compound commands
- Ensure we only submit a new model if actual changes were applied

Relates to  https://github.com/eclipse-glsp/glsp/issues/1477

#### How to test

- Move an element without actually snapping to a new position
- Debug server state or observer undo/redo stack is correctly as there are no operations on the command stack

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog **IF the submission change is accepted as well**
-   [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
  - If the submission change is accepted as well, this may change the behavior in a way that the GModel is not re-generated after an empty operation. Adopters may have relied on that so this would constitute a breaking change as the previous behavior is also valid and may not strictly be classified as a bug.
