### PR TITLE
Improve winston configuration

### DIFF
--- a/packages/server/src/node/di/app-module.ts
+++ b/packages/server/src/node/di/app-module.ts
@@ -74,6 +74,14 @@ export function configureWinstonLogger<T extends LaunchOptions>(
     rebind = true,
     baseLoggerCreator: (launchOptions: T) => winston.Logger = createWinstonInstance
 ): void {
+    if (rebind) {
+        if (context.isBound(Logger)) {
+            context.unbind(Logger);
+        }
+        if (context.isBound(LoggerFactory)) {
+            context.unbind(LoggerFactory);
+        }
+    }
     context.bind(LoggerFactory).toFactory(dynamicContext => (caller: string) => {
         const logger = dynamicContext.container.get(Logger);
         logger.caller = caller;
@@ -87,14 +95,6 @@ export function configureWinstonLogger<T extends LaunchOptions>(
     }
 
     const baseLogger = baseLoggerCreator(options);
-    if (rebind) {
-        if (context.isBound(Logger)) {
-            context.unbind(Logger);
-        }
-        if (context.isBound(LoggerFactory)) {
-            context.unbind(LoggerFactory);
-        }
-    }
 
     context.bind(Logger).toDynamicValue(dynamicContext => new WinstonLogger(baseLogger, getRequestParentName(dynamicContext)));
 }

--- a/packages/server/src/node/di/app-module.ts
+++ b/packages/server/src/node/di/app-module.ts
@@ -16,7 +16,7 @@
 import { BindingContext } from '@eclipse-glsp/protocol/lib/di';
 import { ContainerModule } from 'inversify';
 import * as winston from 'winston';
-import { InjectionContainer, LogLevel, Logger, LoggerFactory, getRequestParentName } from '../../common';
+import { InjectionContainer, LogLevel, Logger, LoggerFactory, NullLogger, getRequestParentName } from '../../common';
 import { LaunchOptions } from '../launch/cli-parser';
 import { WinstonLogger } from './winston-logger';
 
@@ -74,6 +74,18 @@ export function configureWinstonLogger<T extends LaunchOptions>(
     rebind = true,
     baseLoggerCreator: (launchOptions: T) => winston.Logger = createWinstonInstance
 ): void {
+    context.bind(LoggerFactory).toFactory(dynamicContext => (caller: string) => {
+        const logger = dynamicContext.container.get(Logger);
+        logger.caller = caller;
+        return logger;
+    });
+
+    // if no logging is enabled, bind the NullLogger
+    if (!options.consoleLog && !options.fileLog) {
+        context.bind(Logger).to(NullLogger).inSingletonScope();
+        return;
+    }
+
     const baseLogger = baseLoggerCreator(options);
     if (rebind) {
         if (context.isBound(Logger)) {
@@ -85,9 +97,4 @@ export function configureWinstonLogger<T extends LaunchOptions>(
     }
 
     context.bind(Logger).toDynamicValue(dynamicContext => new WinstonLogger(baseLogger, getRequestParentName(dynamicContext)));
-    context.bind(LoggerFactory).toFactory(dynamicContext => (caller: string) => {
-        const logger = dynamicContext.container.get(Logger);
-        logger.caller = caller;
-        return logger;
-    });
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Avoid unnecessary instanciation of the winston logger if logging is disabled via options (noConsoleLog and noFilelog are true)

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start the server with noConsoleLog enabled. On master this prints a warning since we still instantiate the winston logger although both console and file log are disabled:

```ts
❯ yarn start --no-consoleLog
yarn run v1.22.22
$ yarn --cwd examples/workflow-server-bundled start --no-consoleLog
$ node --enable-source-maps ./wf-glsp-server-node.js --port 5007 --no-consoleLog
[winston] Attempt to write logs with no transports, which can increase memory usage: {"message":"[SocketServerLauncher] The GLSP server is ready to accept new client requests on port: 5007 ","level":"info"}
[GLSP-Server]:Startup completed. Accepting requests on port:5007
```

With the PR this should be fixed.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
