### PR TITLE
GLSP-1313: Update elkjs

### DIFF
--- a/packages/layout-elk/package.json
+++ b/packages/layout-elk/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@eclipse-glsp/server": "2.5.0-next",
-    "elkjs": "^0.7.1"
+    "elkjs": "^0.10.1"
   },
   "peerDependencies": {
     "inversify": "^6.1.3"

--- a/packages/server/src/common/features/model/model-state.ts
+++ b/packages/server/src/common/features/model/model-state.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GModelRoot } from '@eclipse-glsp/graph';
-import { EditMode } from '@eclipse-glsp/protocol';
+import { EditMode, ProposalString } from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import { ClientId } from '../../di/service-identifiers';
 import { GModelIndex } from './gmodel-index';
@@ -29,7 +29,7 @@ export interface ModelState {
     clear(key: string): void;
     readonly root: GModelRoot;
     updateRoot(newRoot: GModelRoot): void;
-    editMode: string;
+    editMode: ProposalString<EditMode>;
     sourceUri?: string;
     clientId: string;
     readonly isReadonly: boolean;
@@ -53,7 +53,7 @@ export class DefaultModelState implements ModelState {
 
     protected _root: GModelRoot;
 
-    editMode = EditMode.EDITABLE;
+    editMode: ProposalString<EditMode> = EditMode.EDITABLE;
 
     set<P>(key: string, property: P): void {
         this.properties.set(key, property);

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,9 +310,9 @@
     prettier-plugin-packagejson "~2.4.6"
 
 "@eclipse-glsp/protocol@next":
-  version "2.5.0-next.418"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.5.0-next.418.tgz#6434d1b5f8d2bbf518d7f1eeda926cb64f31dbc1"
-  integrity sha512-cb4zPGO18JFowSXlEOyESYW/Zbnklrk1yFVvwGIco5ZMJilea57FGhQDaaCY7W1LgwNwy6gzpqNDstls/FiZjg==
+  version "2.5.0-next.422"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.5.0-next.422.tgz#26361d1ede063d8fe285c59ccd4bdc6e0c253766"
+  integrity sha512-+w+6SZKNYp6xpxtlvFYOjAvMrC3Ale9HPQ2lSCo2HlK1PS/Vn5pRd20nFuv0afXE8RCJLAABPaQnEiqXrETAwQ==
   dependencies:
     sprotty-protocol "1.4.0"
     uuid "~10.0.0"
@@ -2672,10 +2672,10 @@ electron-to-chromium@^1.4.668:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.767.tgz#b885cfefda5a2e7a7ee356c567602012294ed260"
   integrity sha512-nzzHfmQqBss7CE3apQHkHjXW77+8w3ubGCIoEijKCJebPufREaFETgGXWTkh32t259F3Kcq+R8MZdFdOJROgYw==
 
-elkjs@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.7.1.tgz#4751c5e918a4988139baf7f214e010aea22de969"
-  integrity sha512-lD86RWdh480/UuRoHhRcnv2IMkIcK6yMDEuT8TPBIbO3db4HfnVF+1lgYdQi99Ck0yb+lg5Eb46JCHI5uOsmAw==
+elkjs@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.10.1.tgz#37d52f9320c22e9f3ed6cadbb5b9f648c539d256"
+  integrity sha512-WMl/p3FTVlC30TidATWOK1TdTiU0AvqTG13tQF7dF71SYTM1vHgSGZNZBvcckaVek2MdBCxPESgIM9gVdTkYJw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
- Update to elkjs 0.10.1
- Ensure that Logger can used in elkLayoutModule
- Update GLSPElkLayoutEngine
- Fix typing issue of GModelState.editMode


Fixes eclipse-glsp/glsp/issues/1313
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Can be tested with the standalone example. Invoking the layout command (Ctrl+Shift+L) should work as before.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
- [layout] Updated `GLSPElkLayoutEngine` for `elkjs` > 0.10.1.
     - `GLSPElkLayoutEngine`: Replaced usages of the `deprecated` and no longer supported `ELKPrimitiveEdge`. This might affect adopters that use a customization of this class
