### PR TITLE
Add optional LayoutOperation parameter to LayoutEngine.layout

### DIFF
--- a/packages/layout-elk/src/glsp-elk-layout-engine.ts
+++ b/packages/layout-elk/src/glsp-elk-layout-engine.ts
@@ -25,6 +25,7 @@ import {
     GPort,
     GShapeElement,
     LayoutEngine,
+    LayoutOperation,
     Logger,
     MaybePromise,
     ModelState,
@@ -66,7 +67,7 @@ export class GlspElkLayoutEngine implements LayoutEngine {
     ) {
         this.elk = elkFactory();
     }
-    layout(): MaybePromise<GModelRoot> {
+    layout(layoutOperation: LayoutOperation): MaybePromise<GModelRoot> {
         const root = this.modelState.root;
         if (!(root instanceof GGraph)) {
             return root;

--- a/packages/server/src/common/features/layout/layout-engine.ts
+++ b/packages/server/src/common/features/layout/layout-engine.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { GModelRoot } from '@eclipse-glsp/graph';
-import { MaybePromise } from '@eclipse-glsp/protocol';
+import { LayoutOperation, MaybePromise } from '@eclipse-glsp/protocol';
 
 /**
  * A layout engine is able to compute layout information for a model.
@@ -23,9 +23,10 @@ import { MaybePromise } from '@eclipse-glsp/protocol';
 export interface LayoutEngine {
     /**
      * Computes a layout for the model state and modify the model accordingly.
+     * @param layoutOperation, optional layoutOperation param to allow passing in of enriched layout information.
      * @returns the layouted {@link GModelRoot}.
      */
-    layout(): MaybePromise<GModelRoot>;
+    layout(layoutOperation?: LayoutOperation): MaybePromise<GModelRoot>;
 }
 
 export const LayoutEngine = Symbol('LayoutEngine');


### PR DESCRIPTION
https://github.com/eclipse-glsp/glsp/issues/1561

Adds an optional LayoutOperation parameter to LayoutEngine.layout, this allows the LayoutEngine to access information passed from the client such as the canvasBounds along with the viewport scroll and zoom.

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
