### PR TITLE
GLSP-1565: Use separate source maps for web bundle

### DIFF
--- a/examples/workflow-server-bundled-web/package.json
+++ b/examples/workflow-server-bundled-web/package.json
@@ -34,10 +34,11 @@
   ],
   "main": "./wf-glsp-server-webworker.js",
   "files": [
-    "wf-glsp-server-webworker.js"
+    "wf-glsp-server-webworker.js",
+    "wf-glsp-server-webworker.js.map"
   ],
   "scripts": {
-    "clean": "rimraf wf-glsp-server-webworker.js"
+    "clean": "rimraf wf-glsp-server-webworker.js wf-glsp-server-webworker.js.map"
   },
   "publishConfig": {
     "access": "public"

--- a/examples/workflow-server/src/browser/example1.json
+++ b/examples/workflow-server/src/browser/example1.json
@@ -1,694 +1,750 @@
 {
+  "cssClasses": [],
+  "type": "graph",
+  "position": {
+    "x": 0,
+    "y": 0
+  },
   "id": "sprotty",
+  "revision": 1,
   "children": [
     {
-      "name": "Push",
-      "taskType": "manual",
-      "id": "task0",
-      "cssClasses": ["task", "manual"],
-      "children": [
-        {
-          "id": "task0_icon",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "task0_classname",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 31.921875,
-            "height": 16.0
-          },
-          "text": "Push",
-          "alignment": {
-            "x": 15.9609375,
-            "y": 13.0
-          }
-        }
-      ],
-      "type": "task:manual",
-      "position": {
-        "x": 70.0,
-        "y": 140.0
-      },
-      "size": {
-        "width": 72.921875,
-        "height": 30.0
-      },
-      "layout": "hbox",
-      "layoutOptions": {
-        "paddingRight": 10.0,
-        "prefWidth": 72.921875,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "name": "ChkWt",
-      "taskType": "automated",
-      "id": "task0_automated",
       "cssClasses": ["task", "automated"],
-      "children": [
-        {
-          "id": "task0_automated_icon",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "task0_automated_classname",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 42.1103515625,
-            "height": 16.0
-          },
-          "text": "ChkWt",
-          "alignment": {
-            "x": 21.0,
-            "y": 13.0
-          }
-        }
-      ],
       "type": "task:automated",
-      "position": {
-        "x": 220.0,
-        "y": 90.0
-      },
-      "size": {
-        "width": 83.1103515625,
-        "height": 30.0
-      },
+      "id": "task_ChkTp",
       "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 75.6103515625,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
       "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "nodeType": "mergeNode",
-      "id": "activityNode1",
-      "type": "activityNode:merge",
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
       "position": {
-        "x": 500.0,
-        "y": 90.0
+        "x": 220,
+        "y": 150
       },
-      "size": {
-        "width": 32.0,
-        "height": 32.0
-      },
-      "layoutOptions": {
-        "minHeight": 32.0,
-        "resizeContainer": false
-      }
-    },
-    {
-      "nodeType": "decisionNode",
-      "id": "activityNode2",
-      "type": "activityNode:decision",
-      "position": {
-        "x": 330.0,
-        "y": 190.0
-      },
-      "size": {
-        "width": 32.0,
-        "height": 32.0
-      },
-      "layoutOptions": {
-        "minWidth": 32.0,
-        "minHeight": 32.0
-      }
-    },
-    {
-      "nodeType": "mergeNode",
-      "id": "activityNode4",
-      "type": "activityNode:merge",
-      "position": {
-        "x": 500.0,
-        "y": 190.0
-      },
-      "size": {
-        "width": 32.0,
-        "height": 32.0
-      },
-      "layoutOptions": {
-        "minHeight": 32.0,
-        "resizeContainer": false
-      }
-    },
-    {
-      "nodeType": "decisionNode",
-      "id": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
-      "type": "activityNode:decision",
-      "position": {
-        "x": 330.0,
-        "y": 90.0
-      },
-      "size": {
-        "width": 32.0,
-        "height": 32.0
-      },
-      "layoutOptions": {
-        "minWidth": 32.0,
-        "minHeight": 32.0
-      }
-    },
-    {
-      "nodeType": "forkNode",
-      "id": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
-      "cssClasses": ["forkOrJoin"],
-      "type": "activityNode:fork",
-      "position": {
-        "x": 170.0,
-        "y": 130.0
-      },
-      "size": {
-        "width": 10.0,
-        "height": 50.0
-      }
-    },
-    {
-      "id": "d34c37e0-e45e-4cfe-a76f-0e9274ed8e60",
-      "type": "edge",
-      "sourceId": "task0",
-      "targetId": "bb2709f5-0ff0-4438-8853-b7e934b506d7"
-    },
-    {
-      "nodeType": "joinNode",
-      "id": "bd94e44e-19f9-446e-89d4-97ca1a63c17b",
-      "cssClasses": ["forkOrJoin"],
-      "type": "activityNode:join",
-      "position": {
-        "x": 560.0,
-        "y": 130.0
-      },
-      "size": {
-        "width": 10.0,
-        "height": 50.0
-      }
-    },
-    {
-      "id": "7296b4a8-55c6-4c61-bddb-deacae77efa6",
-      "type": "edge",
-      "sourceId": "activityNode1",
-      "targetId": "bd94e44e-19f9-446e-89d4-97ca1a63c17b"
-    },
-    {
-      "id": "0471cae4-c754-4e89-8337-96ed1546dd02",
-      "type": "edge",
-      "sourceId": "activityNode4",
-      "targetId": "bd94e44e-19f9-446e-89d4-97ca1a63c17b"
-    },
-    {
-      "name": "WtOK",
-      "taskType": "automated",
-      "id": "e47d5eba-612d-4c43-9aba-2c5502ff4f04",
-      "cssClasses": ["task", "automated"],
-      "children": [
-        {
-          "id": "e47d5eba-612d-4c43-9aba-2c5502ff4f04_icon",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "e47d5eba-612d-4c43-9aba-2c5502ff4f04_classname",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 37.9931640625,
-            "height": 16.0
-          },
-          "text": "WtOK",
-          "alignment": {
-            "x": 18.671875,
-            "y": 13.0
-          }
-        }
-      ],
-      "type": "task:automated",
-      "position": {
-        "x": 390.0,
-        "y": 120.0
-      },
-      "size": {
-        "width": 78.9931640625,
-        "height": 30.0
-      },
-      "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 71.4931640625,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "id": "2317f24a-034e-4352-8857-d361dc8f5ed7",
-      "cssClasses": ["medium"],
-      "type": "edge:weighted",
-      "sourceId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
-      "targetId": "e47d5eba-612d-4c43-9aba-2c5502ff4f04"
-    },
-    {
-      "id": "0a57ab51-c0b6-4a51-b42e-0192bf3767dc",
-      "type": "edge",
-      "sourceId": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
-      "targetId": "task0_automated",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "id": "7a5d6bc3-c61e-4baa-8556-6015f33269c7",
-      "type": "edge",
-      "sourceId": "task0_automated",
-      "targetId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "name": "RflWt",
-      "taskType": "manual",
-      "id": "a63cfd87-da7c-4846-912b-29040b776bfb",
-      "cssClasses": ["task", "manual"],
-      "children": [
-        {
-          "id": "54f08126-6041-44ce-9d8b-e7a549e48f91",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "6e007d62-d441-4b08-8815-ad59de3b2ca8",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 34.32421875,
-            "height": 16.0
-          },
-          "text": "RflWt",
-          "alignment": {
-            "x": 17.109375,
-            "y": 13.0
-          }
-        }
-      ],
-      "type": "task:manual",
-      "position": {
-        "x": 390.0,
-        "y": 70.0
-      },
-      "size": {
-        "width": 75.32421875,
-        "height": 30.0
-      },
-      "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 67.82421875,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "id": "9bb443d7-44f3-4192-8dd8-1a2782593373",
-      "cssClasses": ["medium"],
-      "type": "edge:weighted",
-      "sourceId": "b00fc494-0fa4-4448-8bf9-162c2c0865e4",
-      "targetId": "a63cfd87-da7c-4846-912b-29040b776bfb"
-    },
-    {
-      "id": "a36985a7-3e61-499c-9bdb-5be2b00cb75c",
-      "type": "edge",
-      "sourceId": "a63cfd87-da7c-4846-912b-29040b776bfb",
-      "targetId": "activityNode1",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "id": "8880cd08-8d90-4408-acd4-6eae218b1650",
-      "type": "edge",
-      "sourceId": "e47d5eba-612d-4c43-9aba-2c5502ff4f04",
-      "targetId": "activityNode1",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "name": "Brew",
-      "taskType": "automated",
-      "id": "7afd430b-5031-4082-8190-7e755c57cde9",
-      "cssClasses": ["task", "automated"],
-      "children": [
-        {
-          "id": "7afd430b-5031-4082-8190-7e755c57cde9_icon",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "7afd430b-5031-4082-8190-7e755c57cde9_classname",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 31.90625,
-            "height": 16.0
-          },
-          "text": "Brew",
-          "alignment": {
-            "x": 15.953125,
-            "y": 13.0
-          }
-        }
-      ],
-      "type": "task:automated",
-      "position": {
-        "x": 600.0,
-        "y": 140.0
-      },
-      "size": {
-        "width": 72.90625,
-        "height": 30.0
-      },
-      "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 72.90625,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "id": "81efd1ef-ae19-4ea6-a20b-20857b1c6552",
-      "type": "edge",
-      "sourceId": "bd94e44e-19f9-446e-89d4-97ca1a63c17b",
-      "targetId": "7afd430b-5031-4082-8190-7e755c57cde9",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
       "name": "ChkTp",
       "taskType": "automated",
-      "id": "6c26f0a4-4354-45fa-9d9f-bc2b48adee17",
-      "cssClasses": ["task", "automated"],
-      "children": [
-        {
-          "id": "6c26f0a4-4354-45fa-9d9f-bc2b48adee17_icon",
-          "type": "icon",
-          "position": {
-            "x": 5.0,
-            "y": 5.0
-          },
-          "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
-        },
-        {
-          "id": "6c26f0a4-4354-45fa-9d9f-bc2b48adee17_classname",
-          "type": "label:heading",
-          "position": {
-            "x": 31.0,
-            "y": 7.0
-          },
-          "size": {
-            "width": 41.4482421875,
-            "height": 16.0
-          },
-          "text": "ChkTp",
-          "alignment": {
-            "x": 20.6171875,
-            "y": 13.0
-          }
-        }
-      ],
-      "type": "task:automated",
-      "position": {
-        "x": 220.0,
-        "y": 190.0
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 82.4482421875,
+        "prefHeight": 30
       },
       "size": {
         "width": 82.4482421875,
-        "height": 30.0
+        "height": 30
       },
-      "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 74.9482421875,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "id": "189aecf6-6043-4915-9f3e-7b2da8fd0d9c",
-      "type": "edge",
-      "sourceId": "bb2709f5-0ff0-4438-8853-b7e934b506d7",
-      "targetId": "6c26f0a4-4354-45fa-9d9f-bc2b48adee17",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "id": "69e45ef0-9c74-41da-a3ab-0a5669f83f96",
-      "type": "edge",
-      "sourceId": "6c26f0a4-4354-45fa-9d9f-bc2b48adee17",
-      "targetId": "activityNode2",
-      "args": {
-        "edgePadding": 10.0
-      }
-    },
-    {
-      "name": "KeepTp",
-      "taskType": "automated",
-      "id": "4b06ed95-c9be-47df-9941-98099259be4a",
-      "cssClasses": ["task", "automated"],
       "children": [
         {
-          "id": "4b06ed95-c9be-47df-9941-98099259be4a_icon",
+          "cssClasses": [],
           "type": "icon",
+          "id": "task_ChkTp_icon",
           "position": {
-            "x": 5.0,
-            "y": 5.0
+            "x": 5,
+            "y": 5
           },
           "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
+            "width": 25,
+            "height": 20
+          },
+          "children": []
         },
         {
-          "id": "4b06ed95-c9be-47df-9941-98099259be4a_classname",
+          "cssClasses": [],
           "type": "label:heading",
+          "alignment": {
+            "x": 20.6171875,
+            "y": 13
+          },
+          "id": "task_ChkTp_label",
+          "text": "ChkTp",
           "position": {
-            "x": 31.0,
-            "y": 7.0
+            "x": 31,
+            "y": 7
           },
           "size": {
-            "width": 49.248046875,
-            "height": 16.0
+            "width": 41.4482421875,
+            "height": 16
           },
-          "text": "KeepTp",
-          "alignment": {
-            "x": 24.5234375,
-            "y": 13.0
-          }
+          "children": []
         }
-      ],
-      "type": "task:automated",
+      ]
+    },
+    {
+      "cssClasses": ["task", "manual"],
+      "type": "task:manual",
+      "id": "task_Push",
+      "layout": "hbox",
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
       "position": {
-        "x": 390.0,
-        "y": 170.0
+        "x": 70,
+        "y": 100
+      },
+      "name": "Push",
+      "taskType": "manual",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 72.921875,
+        "prefHeight": 30
       },
       "size": {
-        "width": 90.248046875,
-        "height": 30.0
+        "width": 72.921875,
+        "height": 30
       },
-      "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 82.748046875,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
-      },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
-    },
-    {
-      "name": "PreHeat",
-      "taskType": "automated",
-      "id": "80d1792f-9c7e-41c0-8eca-eeb0509397b6",
-      "cssClasses": ["task", "automated"],
       "children": [
         {
-          "id": "80d1792f-9c7e-41c0-8eca-eeb0509397b6_icon",
+          "cssClasses": [],
           "type": "icon",
+          "id": "task_Push_icon",
           "position": {
-            "x": 5.0,
-            "y": 5.0
+            "x": 5,
+            "y": 5
           },
           "size": {
-            "width": 25.0,
-            "height": 20.0
-          }
+            "width": 25,
+            "height": 20
+          },
+          "children": []
         },
         {
-          "id": "80d1792f-9c7e-41c0-8eca-eeb0509397b6_classname",
+          "cssClasses": [],
           "type": "label:heading",
+          "alignment": {
+            "x": 15.9609375,
+            "y": 13
+          },
+          "id": "task_Push_label",
+          "text": "Push",
           "position": {
-            "x": 31.0,
-            "y": 7.0
+            "x": 31,
+            "y": 7
           },
           "size": {
-            "width": 51.46875,
-            "height": 16.0
+            "width": 31.921875,
+            "height": 16
           },
-          "text": "PreHeat",
-          "alignment": {
-            "x": 25.6796875,
-            "y": 13.0
-          }
+          "children": []
         }
-      ],
-      "type": "task:automated",
+      ]
+    },
+    {
+      "cssClasses": ["forkOrJoin"],
+      "type": "activityNode:fork",
+      "id": "fork_1",
       "position": {
-        "x": 390.0,
-        "y": 220.0
+        "x": 170,
+        "y": 90
+      },
+      "nodeType": "forkNode",
+      "size": {
+        "width": 10,
+        "height": 50
+      },
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_Push_fork_1",
+      "sourceId": "task_Push",
+      "targetId": "fork_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_fork1_task_ChkTp",
+      "sourceId": "fork_1",
+      "targetId": "task_ChkTp",
+      "children": []
+    },
+    {
+      "cssClasses": ["task", "automated"],
+      "type": "task:automated",
+      "id": "task_ChkWt",
+      "layout": "hbox",
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
+      "position": {
+        "x": 220,
+        "y": 50
+      },
+      "name": "ChkWt",
+      "taskType": "automated",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 83.1103515625,
+        "prefHeight": 30
+      },
+      "size": {
+        "width": 83.1103515625,
+        "height": 30
+      },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_ChkWt_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 21,
+            "y": 13
+          },
+          "id": "task_ChkWt_label",
+          "text": "ChkWt",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 42.1103515625,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
+    },
+    {
+      "cssClasses": ["decision"],
+      "type": "activityNode:decision",
+      "id": "decision_1",
+      "position": {
+        "x": 330,
+        "y": 50
+      },
+      "nodeType": "decisionNode",
+      "size": {
+        "width": 32,
+        "height": 32
+      },
+      "resizeLocations": ["top", "right", "bottom", "left"],
+      "children": []
+    },
+    {
+      "cssClasses": ["decision"],
+      "type": "activityNode:decision",
+      "id": "decision2",
+      "position": {
+        "x": 330,
+        "y": 150
+      },
+      "nodeType": "decisionNode",
+      "size": {
+        "width": 32,
+        "height": 32
+      },
+      "resizeLocations": ["top", "right", "bottom", "left"],
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_ChkWt_decision1",
+      "sourceId": "task_ChkWt",
+      "targetId": "decision_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_fork1_task_ChkWt",
+      "sourceId": "fork_1",
+      "targetId": "task_ChkWt",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_ChkTp_decision2",
+      "sourceId": "task_ChkTp",
+      "targetId": "decision2",
+      "children": []
+    },
+    {
+      "cssClasses": ["task", "automated"],
+      "type": "task:automated",
+      "id": "task_PreHeat",
+      "layout": "hbox",
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
+      "position": {
+        "x": 390,
+        "y": 180
+      },
+      "name": "PreHeat",
+      "taskType": "automated",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 92.46875,
+        "prefHeight": 30
       },
       "size": {
         "width": 92.46875,
-        "height": 30.0
+        "height": 30
       },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_PreHeat_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 25.6796875,
+            "y": 13
+          },
+          "id": "task_PreHeat_label",
+          "text": "PreHeat",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 51.46875,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
+    },
+    {
+      "cssClasses": ["task", "automated"],
+      "type": "task:automated",
+      "id": "task_KeepTp",
       "layout": "hbox",
-      "layoutOptions": {
-        "prefWidth": 84.96875,
-        "paddingRight": 10.0,
-        "prefHeight": 30.0
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
       },
-      "args": {
-        "radiusBottomLeft": 5.0,
-        "radiusTopLeft": 5.0,
-        "radiusTopRight": 5.0,
-        "radiusBottomRight": 5.0
-      }
+      "position": {
+        "x": 390,
+        "y": 130
+      },
+      "name": "KeepTp",
+      "taskType": "automated",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 90.248046875,
+        "prefHeight": 30
+      },
+      "size": {
+        "width": 90.248046875,
+        "height": 30
+      },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_KeepTp_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 24.5234375,
+            "y": 13
+          },
+          "id": "task_KeepTp_label",
+          "text": "KeepTp",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 49.248046875,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
     },
     {
-      "id": "d04afaf8-0894-4284-b844-22b255893107",
+      "cssClasses": ["task", "manual"],
+      "type": "task:manual",
+      "id": "task_RflWt",
+      "layout": "hbox",
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
+      "position": {
+        "x": 390,
+        "y": 20
+      },
+      "name": "RflWt",
+      "taskType": "manual",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 75.32421875,
+        "prefHeight": 30
+      },
+      "size": {
+        "width": 75.32421875,
+        "height": 30
+      },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_RflWt_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 17.109375,
+            "y": 13
+          },
+          "id": "task_RflWt_label",
+          "text": "RflWt",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 34.32421875,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
+    },
+    {
+      "cssClasses": ["task", "automated"],
+      "type": "task:automated",
+      "id": "task_WtOK",
+      "layout": "hbox",
+      "args": {
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
+      "position": {
+        "x": 390,
+        "y": 80
+      },
+      "name": "WtOK",
+      "taskType": "automated",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 78.9931640625,
+        "prefHeight": 30
+      },
+      "size": {
+        "width": 78.9931640625,
+        "height": 30
+      },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_WtOK_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 18.671875,
+            "y": 13
+          },
+          "id": "task_WtOK_label",
+          "text": "WtOK",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 37.9931640625,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
+    },
+    {
       "cssClasses": ["medium"],
       "type": "edge:weighted",
-      "sourceId": "activityNode2",
-      "targetId": "4b06ed95-c9be-47df-9941-98099259be4a"
+      "routingPoints": [],
+      "id": "edge_decision1_task_RflWt",
+      "sourceId": "decision_1",
+      "targetId": "task_RflWt",
+      "probability": "medium",
+      "children": []
     },
     {
-      "id": "b9ef468f-2aaf-41b9-b408-29e2d08e490e",
       "cssClasses": ["medium"],
       "type": "edge:weighted",
-      "sourceId": "activityNode2",
-      "targetId": "80d1792f-9c7e-41c0-8eca-eeb0509397b6"
+      "routingPoints": [],
+      "id": "edge_decision_1_task_WtOK",
+      "sourceId": "decision_1",
+      "targetId": "task_WtOK",
+      "probability": "medium",
+      "children": []
     },
     {
-      "id": "58657bcf-6d32-4e7d-b73a-f84fd8d7158b",
-      "type": "edge",
-      "sourceId": "4b06ed95-c9be-47df-9941-98099259be4a",
-      "targetId": "activityNode4",
-      "args": {
-        "edgePadding": 10.0
-      }
+      "cssClasses": ["medium"],
+      "type": "edge:weighted",
+      "routingPoints": [],
+      "id": "edege_decision_2_task_KeepTp",
+      "sourceId": "decision2",
+      "targetId": "task_KeepTp",
+      "probability": "medium",
+      "children": []
     },
     {
-      "id": "39a75477-facf-4960-b0bb-1989be7fb57f",
-      "type": "edge",
-      "sourceId": "80d1792f-9c7e-41c0-8eca-eeb0509397b6",
-      "targetId": "activityNode4",
+      "cssClasses": ["medium"],
+      "type": "edge:weighted",
+      "routingPoints": [],
+      "id": "edege_decision2_task_PreHeat",
+      "sourceId": "decision2",
+      "targetId": "task_PreHeat",
+      "probability": "medium",
+      "children": []
+    },
+    {
+      "cssClasses": ["forkOrJoin"],
+      "type": "activityNode:join",
+      "id": "join_1",
+      "position": {
+        "x": 560,
+        "y": 90
+      },
+      "nodeType": "joinNode",
+      "size": {
+        "width": 10,
+        "height": 50
+      },
+      "children": []
+    },
+    {
+      "cssClasses": ["task", "automated"],
+      "type": "task:automated",
+      "id": "task_Brew",
+      "layout": "hbox",
       "args": {
-        "edgePadding": 10.0
-      }
+        "radiusTopLeft": 5,
+        "radiusBottomLeft": 5,
+        "radiusBottomRight": 5,
+        "radiusTopRight": 5
+      },
+      "position": {
+        "x": 600,
+        "y": 100
+      },
+      "name": "Brew",
+      "taskType": "automated",
+      "layoutOptions": {
+        "paddingRight": 10,
+        "prefWidth": 73.20530319213867,
+        "prefHeight": 30
+      },
+      "size": {
+        "width": 73.20530319213867,
+        "height": 30
+      },
+      "children": [
+        {
+          "cssClasses": [],
+          "type": "icon",
+          "id": "task_Brew_icon",
+          "position": {
+            "x": 5,
+            "y": 5
+          },
+          "size": {
+            "width": 25,
+            "height": 20
+          },
+          "children": []
+        },
+        {
+          "cssClasses": [],
+          "type": "label:heading",
+          "alignment": {
+            "x": 15.953125,
+            "y": 13
+          },
+          "id": "task_Brew_label",
+          "text": "Brew",
+          "position": {
+            "x": 31,
+            "y": 7
+          },
+          "size": {
+            "width": 31.90625,
+            "height": 16
+          },
+          "children": []
+        }
+      ]
+    },
+    {
+      "cssClasses": ["merge"],
+      "type": "activityNode:merge",
+      "id": "merge_1",
+      "position": {
+        "x": 500,
+        "y": 50
+      },
+      "nodeType": "mergeNode",
+      "size": {
+        "width": 32,
+        "height": 32
+      },
+      "resizeLocations": ["top", "right", "bottom", "left"],
+      "children": []
+    },
+    {
+      "cssClasses": ["merge"],
+      "type": "activityNode:merge",
+      "id": "merge_2",
+      "position": {
+        "x": 500,
+        "y": 150
+      },
+      "nodeType": "mergeNode",
+      "size": {
+        "width": 32,
+        "height": 32
+      },
+      "resizeLocations": ["top", "right", "bottom", "left"],
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_RflWt_merge_1",
+      "sourceId": "task_RflWt",
+      "targetId": "merge_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_WTOK_merge_1",
+      "sourceId": "task_WtOK",
+      "targetId": "merge_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_task_KeepTp_merge_2",
+      "sourceId": "task_KeepTp",
+      "targetId": "merge_2",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edege_task_PreHeat_merge_2",
+      "sourceId": "task_PreHeat",
+      "targetId": "merge_2",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_merge_2_join_1",
+      "sourceId": "merge_2",
+      "targetId": "join_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_merge_1_join_1",
+      "sourceId": "merge_1",
+      "targetId": "join_1",
+      "children": []
+    },
+    {
+      "cssClasses": [],
+      "type": "edge",
+      "routingPoints": [],
+      "id": "edge_join_1_task_Brew",
+      "sourceId": "join_1",
+      "targetId": "task_Brew",
+      "children": []
     }
-  ],
-  "type": "graph",
-  "revision": 10
+  ]
 }

--- a/examples/workflow-server/webpack.config.js
+++ b/examples/workflow-server/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = env => {
             path: appRoot
         },
         mode: 'development',
-        devtool: target !== 'node' ? 'inline-source-map' : 'source-map',
+        devtool: 'source-map',
         resolve: {
             extensions: ['.js']
         },


### PR DESCRIPTION
## Summary
Follow-up to #132.

- Switch from inline to separate source map files for the webworker bundle
- Include `.map` file in published package
-  Sync example1.wf with client variant

## Test plan
- [ ] `yarn build` produces both `.js` and `.js.map` in `examples/workflow-server-bundled-web/`