### PR TITLE
fix: correct publish workflow branch filter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     workflows: ['CI']
     types:
       - completed
-    branches: [master]
+    branches: [main]
   workflow_call:
     inputs:
       ref:


### PR DESCRIPTION
## Summary
- The `workflow_run` trigger in `publish.yml` was filtering on `master`, but the default branch is `main`
- This caused auto-publishing to never fire after CI completed on `main`
