### PR TITLE
GLSP-1692: Fix elkfactory for browser usecase

### DIFF
--- a/packages/layout-elk/src/di.config.ts
+++ b/packages/layout-elk/src/di.config.ts
@@ -24,6 +24,7 @@ import {
     applyBindingTarget
 } from '@eclipse-glsp/server';
 import ElkConstructor, { LayoutOptions } from 'elkjs/lib/elk.bundled';
+import { ELK } from 'elkjs/lib/elk-api';
 import { ContainerModule, injectable, interfaces } from 'inversify';
 import { DefaultElementFilter, ElementFilter } from './element-filter';
 import { ElkFactory, GlspElkLayoutEngine } from './glsp-elk-layout-engine';
@@ -104,15 +105,35 @@ export class ElkLayoutModule extends GLSPModule {
 
     protected bindElkFactory(): BindingTarget<ElkFactory> {
         const { algorithms, defaultLayoutOptions, isWebWorker } = this.options;
-        const factory: ElkFactory = () =>
-            new ElkConstructor({
-                algorithms,
-                defaultLayoutOptions,
-                // The node implementation relies on elkjs' `FakeWorker` to set the `workerFactory`. The required file is
-                // dynamically loaded and not available in a web-worker context, so it has to be mocked manually there.
-                workerFactory: isWebWorker ? () => ({ postMessage: () => {} }) as unknown as Worker : undefined
-            });
+        const factory: ElkFactory = () => this.createElk({ algorithms, defaultLayoutOptions }, isWebWorker);
         return { constantValue: factory };
+    }
+
+    /** Creates the underlying elkjs {@link ELK} instance, see {@link createWebWorkerElk} for the web-worker case. */
+    protected createElk(options: { algorithms: string[]; defaultLayoutOptions?: LayoutOptions }, isWebWorker?: boolean): ELK {
+        return isWebWorker ? this.createWebWorkerElk(options) : new ElkConstructor(options);
+    }
+
+    /**
+     * Creates an {@link ELK} instance for a web-worker server. elkjs only exposes its in-process fake worker when it
+     * doesn't detect a dedicated-worker scope (`self` present, `document` absent) — otherwise it hijacks
+     * `self.onmessage` and layout never runs. Briefly presenting a `document` during construction flips elkjs back to
+     * the in-process worker without touching the server's own `self.onmessage` handler.
+     */
+    protected createWebWorkerElk(options: { algorithms: string[]; defaultLayoutOptions?: LayoutOptions }): ELK {
+        const globalScope = globalThis as { document?: unknown };
+        const hadDocument = 'document' in globalScope;
+        const previousDocument = globalScope.document;
+        globalScope.document = previousDocument ?? {};
+        try {
+            return new ElkConstructor(options);
+        } finally {
+            if (hadDocument) {
+                globalScope.document = previousDocument;
+            } else {
+                delete globalScope.document;
+            }
+        }
     }
 
     protected bindGlspElkLayoutEngine(): BindingTarget<GlspElkLayoutEngine> {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does
Replace no-op elk factory with proper setup for isWebworker context. A small workaround/hack is required to present a `document` during construction of the factory which routes elkjs to the c orrect in-process message worker

Fixes eclipse-glsp/glsp#1692

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
-  To test locally, checkout glsp-client master alongside the server-node repo and run
```bash
yarn dev:browser --external-server /path/tp/glsp-server-node/examples/workflow-server-bundled-web/wf-glsp-server-webworker.js
```

Then trigger a layout via Ctrl+Shift+L

I have already verified this locally. It might be easier to simple merge this after a positive code reivew and directly test in the glsp-client repo without the --external-server workaround.


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
         Replaces the no-op webworker in the browser context with an actual working implementation. 
         Adopters that relied on the fact that the elkLayoutModule was effectivly no-op in the browser might need to adopt accordingly