### PR TITLE
Fix no-op test assertions and drop redundant eslint overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,12 +97,4 @@ export default [
             ]
         }
     },
-    // Test file overrides
-    {
-        files: ['**/*.spec.{ts,tsx}'],
-        rules: {
-            '@typescript-eslint/no-unused-expressions': 'off',
-            'import-x/namespace': 'off'
-        }
-    }
 ];

--- a/packages/server/src/common/actions/action-handler-registry.spec.ts
+++ b/packages/server/src/common/actions/action-handler-registry.spec.ts
@@ -36,10 +36,10 @@ describe('Test ActionHandlerRegistry (only functionality that is not covered by 
 
         const result = registry.getAll();
         expect(result).toHaveLength(4);
-        expect(result.includes(h1)).true;
-        expect(result.includes(h2)).true;
-        expect(result.includes(h3)).true;
-        expect(result.includes(h4)).true;
+        expect(result.includes(h1)).toBe(true);
+        expect(result.includes(h2)).toBe(true);
+        expect(result.includes(h3)).toBe(true);
+        expect(result.includes(h4)).toBe(true);
     });
 
     it('get - should return three handlers sorted by priority', () => {

--- a/packages/server/src/common/actions/global-action-provider.spec.ts
+++ b/packages/server/src/common/actions/global-action-provider.spec.ts
@@ -62,6 +62,6 @@ describe('test DefaultGlobalActionProvider', () => {
         expect(result.size).toBe(1);
         const resultServerActions = result.get(diagramType);
         expect(resultServerActions).toBeDefined();
-        expect(serverActions.every(action => resultServerActions!.includes(action))).true;
+        expect(serverActions.every(action => resultServerActions!.includes(action))).toBe(true);
     });
 });

--- a/packages/server/src/common/di/multi-bindings.spec.ts
+++ b/packages/server/src/common/di/multi-bindings.spec.ts
@@ -34,7 +34,7 @@ describe('test implementations of MultiBinding', () => {
         const binding = new MultiBinding('TestClass');
         it('add - new binding', () => {
             binding.add(TestClass1);
-            expect(binding.contains(TestClass1)).true;
+            expect(binding.contains(TestClass1)).toBe(true);
 
             const result = binding.getAll();
             expect(result.length).toBe(1);
@@ -48,9 +48,9 @@ describe('test implementations of MultiBinding', () => {
         });
 
         it('remove - existing binding', () => {
-            expect(binding.contains(TestClass1)).true;
+            expect(binding.contains(TestClass1)).toBe(true);
             binding.remove(TestClass1);
-            expect(binding.contains(TestClass1)).false;
+            expect(binding.contains(TestClass1)).toBe(false);
             expect(binding.getAll()).toHaveLength(0);
         });
 
@@ -65,24 +65,24 @@ describe('test implementations of MultiBinding', () => {
 
             const result = binding.getAll();
             expect(result.length).toBe(2);
-            expect(result.includes(TestClass1)).true;
-            expect(result.includes(TestClass2)).true;
+            expect(result.includes(TestClass1)).toBe(true);
+            expect(result.includes(TestClass2)).toBe(true);
         });
 
         it('rebind- TestClass2 to TestClass3', () => {
             binding.rebind(TestClass2, TestClass3);
             const result = binding.getAll();
             expect(result.length).toBe(2);
-            expect(result.includes(TestClass1)).true;
-            expect(result.includes(TestClass3)).true;
+            expect(result.includes(TestClass1)).toBe(true);
+            expect(result.includes(TestClass3)).toBe(true);
         });
 
         it('rebind- TestClass2 to TestClass3- should fail', () => {
             binding.rebind(TestClass2, TestClass3);
             const result = binding.getAll();
             expect(result.length).toBe(2);
-            expect(result.includes(TestClass1)).true;
-            expect(result.includes(TestClass3)).true;
+            expect(result.includes(TestClass1)).toBe(true);
+            expect(result.includes(TestClass3)).toBe(true);
         });
 
         it('removeAll- TestClass1 & TestClass3', () => {
@@ -125,9 +125,9 @@ describe('test implementations of MultiBinding', () => {
             testContainer.load(testModule);
             const result = testContainer.get<string[]>(identifier);
             expect(result).toHaveLength(3);
-            expect(result.includes(t1)).true;
-            expect(result.includes(t2)).true;
-            expect(result.includes(t3)).true;
+            expect(result.includes(t1)).toBe(true);
+            expect(result.includes(t2)).toBe(true);
+            expect(result.includes(t3)).toBe(true);
         });
     });
 });

--- a/packages/server/src/common/features/type-hints/request-type-hints-action-handler.spec.ts
+++ b/packages/server/src/common/features/type-hints/request-type-hints-action-handler.spec.ts
@@ -51,7 +51,7 @@ describe('test RequestTypeHintsActionHandler', () => {
         const result = await handler.execute(RequestTypeHintsAction.create());
 
         expect(result).toHaveLength(1);
-        expect(SetTypeHintsAction.is(result[0])).true;
+        expect(SetTypeHintsAction.is(result[0])).toBe(true);
         expect(result).toEqual([
             { edgeHints: [edgeTypeHint], kind: 'setTypeHints', shapeHints: [shapeTypeHint], responseId: '' } as SetTypeHintsAction
         ]);

--- a/packages/server/src/common/session/client-session-manager.spec.ts
+++ b/packages/server/src/common/session/client-session-manager.spec.ts
@@ -40,7 +40,7 @@ describe('test DefaultClientSessionManager', () => {
     const sessionManager = container.resolve(DefaultClientSessionManager);
 
     it('add listener', () => {
-        expect(sessionManager.addListener(testSessionListener, testSession.id)).true;
+        expect(sessionManager.addListener(testSessionListener, testSession.id)).toBe(true);
     });
 
     it('add create client session', () => {

--- a/packages/server/src/common/utils/promise-queue.spec.ts
+++ b/packages/server/src/common/utils/promise-queue.spec.ts
@@ -88,22 +88,22 @@ describe('test PromiseQueue', () => {
     it('enqueue - one element', async () => {
         const { state, promise } = newTestPromise(100);
         state.onStart(() => {
-            expect(queue.isBusy).true;
+            expect(queue.isBusy).toBe(true);
         });
         const queEnd = queue.enqueue(promise);
-        expect(queue.isEmpty).true;
+        expect(queue.isEmpty).toBe(true);
         await queEnd;
     });
 
     it('enqueue - two elements', async () => {
         const p1 = newTestPromise(100);
-        p1.state.onStop(() => expect(p2.state.started).false);
+        p1.state.onStop(() => expect(p2.state.started).toBe(false));
 
         const p2 = newTestPromise(100);
 
         p2.state.onStart(() => {
-            expect(queue.isEmpty).true;
-            expect(p1.state.stopped).true;
+            expect(queue.isEmpty).toBe(true);
+            expect(p1.state.stopped).toBe(true);
         });
 
         queue.enqueue(p1.promise);
@@ -115,21 +115,21 @@ describe('test PromiseQueue', () => {
     it('enqueue - three elements (first promise in queue has longest resolve time)', async () => {
         const p1 = newTestPromise(300);
         p1.state.onStop(() => {
-            expect(p2.state.started).false;
-            expect(p3.state.started).false;
+            expect(p2.state.started).toBe(false);
+            expect(p3.state.started).toBe(false);
         });
 
         const p2 = newTestPromise(200);
         p2.state.onStart(() => {
             expect(queue.size).toBe(1);
-            expect(p1.state.stopped).true;
-            expect(p3.state.started).false;
+            expect(p1.state.stopped).toBe(true);
+            expect(p3.state.started).toBe(false);
         });
 
         const p3 = newTestPromise(100);
         p3.state.onStart(() => {
-            expect(queue.isEmpty).true;
-            expect(p2.state.stopped).true;
+            expect(queue.isEmpty).toBe(true);
+            expect(p2.state.stopped).toBe(true);
         });
 
         queue.enqueue(p1.promise);

--- a/packages/server/src/common/utils/registry.spec.ts
+++ b/packages/server/src/common/utils/registry.spec.ts
@@ -28,7 +28,7 @@ describe('Test Registry', () => {
     it('register - with new key-value pair', () => {
         const key = 'key';
         const value = 'value';
-        expect(registry.register(key, value)).true;
+        expect(registry.register(key, value)).toBe(true);
         expect(registry.get(key), value);
     });
 
@@ -36,9 +36,9 @@ describe('Test Registry', () => {
         // Setup
         const key = 'key';
         const value = 'value';
-        expect(registry.register(key, value)).true;
+        expect(registry.register(key, value)).toBe(true);
         // Test execution
-        expect(registry.register(key, 'newValue')).false;
+        expect(registry.register(key, 'newValue')).toBe(false);
         expect(registry.get(key), value);
     });
 
@@ -46,34 +46,34 @@ describe('Test Registry', () => {
         // Setup
         const key = 'key';
         const value = 'value';
-        expect(registry.register(key, value)).true;
+        expect(registry.register(key, value)).toBe(true);
         // Test execution
-        expect(registry.deregister(key)).true;
+        expect(registry.deregister(key)).toBe(true);
         expect(registry.get(key), undefined);
     });
 
     it('deregister - with unregistered key', () => {
-        expect(registry.deregister('unregisteredKey')).false;
+        expect(registry.deregister('unregisteredKey')).toBe(false);
     });
 
     it('haskey - with registered key', () => {
         // Setup
         const key = 'key';
         const value = 'value';
-        expect(registry.register(key, value)).true;
+        expect(registry.register(key, value)).toBe(true);
         // Test execution
-        expect(registry.hasKey(key)).true;
+        expect(registry.hasKey(key)).toBe(true);
     });
 
     it('haskey - with unregistered key', () => {
-        expect(registry.deregister('unregisteredKey')).false;
+        expect(registry.deregister('unregisteredKey')).toBe(false);
     });
 
     it('get - with registered key', () => {
         // Setup
         const key = 'key';
         const value = 'value';
-        expect(registry.register(key, value)).true;
+        expect(registry.register(key, value)).toBe(true);
         // Test execution
         expect(registry.get(key), value);
     });
@@ -93,9 +93,9 @@ describe('Test Registry', () => {
         // Test execution
         const result = registry.getAll();
         expect(result).toHaveLength(3);
-        expect(result.includes(e1.value)).true;
-        expect(result.includes(e2.value)).true;
-        expect(result.includes(e3.value)).true;
+        expect(result.includes(e1.value)).toBe(true);
+        expect(result.includes(e2.value)).toBe(true);
+        expect(result.includes(e3.value)).toBe(true);
     });
 
     it('keys - should return three keys', () => {
@@ -109,9 +109,9 @@ describe('Test Registry', () => {
         // Test execution
         const result = registry.keys();
         expect(result).toHaveLength(3);
-        expect(result.includes(e1.key)).true;
-        expect(result.includes(e2.key)).true;
-        expect(result.includes(e3.key)).true;
+        expect(result.includes(e1.key)).toBe(true);
+        expect(result.includes(e2.key)).toBe(true);
+        expect(result.includes(e3.key)).toBe(true);
     });
 });
 
@@ -133,8 +133,8 @@ describe('Test MapMultiRegistry', () => {
         const resultValue = multiRegistry.get(e1.key);
         expect(resultValue).toBeDefined();
         expect(resultValue!.length).toBe(2);
-        expect(resultValue!.includes(e1.value)).true;
-        expect(resultValue!.includes(e2.value)).true;
+        expect(resultValue!.includes(e1.value)).toBe(true);
+        expect(resultValue!.includes(e2.value)).toBe(true);
     });
 
     it('deregister - with registered key', () => {
@@ -144,14 +144,14 @@ describe('Test MapMultiRegistry', () => {
         multiRegistry.register(key, existingValue[0]);
         multiRegistry.register(key, existingValue[1]);
         // Test execution
-        expect(multiRegistry.deregister(key, existingValue[1])).true;
+        expect(multiRegistry.deregister(key, existingValue[1])).toBe(true);
         const result = multiRegistry.get(key);
         expect(result.length).toBe(1);
         expect(result[0], existingValue[0]);
     });
 
     it('deregister - with unregistered key', () => {
-        expect(multiRegistry.deregister('unregisteredKey', 'someValue')).false;
+        expect(multiRegistry.deregister('unregisteredKey', 'someValue')).toBe(false);
     });
 
     it('deregisterAll - with registered key', () => {
@@ -160,12 +160,12 @@ describe('Test MapMultiRegistry', () => {
         const existingValue = ['value', 'value2'];
         multiRegistry.register(key, existingValue[0]);
         multiRegistry.register(key, existingValue[1]);
-        expect(multiRegistry.deregisterAll(key)).true;
+        expect(multiRegistry.deregisterAll(key)).toBe(true);
         expect(multiRegistry.get(key)).toHaveLength(0);
     });
 
     it('deregisterAll - with unregistered key', () => {
-        expect(multiRegistry.deregisterAll('unregisteredKey')).false;
+        expect(multiRegistry.deregisterAll('unregisteredKey')).toBe(false);
     });
 
     it('haskey - with registered key', () => {
@@ -174,11 +174,11 @@ describe('Test MapMultiRegistry', () => {
         const existingValue = 'value';
         multiRegistry.register(key, existingValue);
         // Test execution
-        expect(multiRegistry.hasKey(key)).true;
+        expect(multiRegistry.hasKey(key)).toBe(true);
     });
 
     it('haskey - with unregistered key', () => {
-        expect(multiRegistry.hasKey('unregisteredKey')).false;
+        expect(multiRegistry.hasKey('unregisteredKey')).toBe(false);
     });
 
     it('get - with registered key', () => {
@@ -188,7 +188,7 @@ describe('Test MapMultiRegistry', () => {
         multiRegistry.register(key, existingValue);
         // Test execution
         expect(multiRegistry.get(key).length).toBe(1);
-        expect(multiRegistry.get(key).includes(existingValue)).true;
+        expect(multiRegistry.get(key).includes(existingValue)).toBe(true);
     });
 
     it('get - with unregistered key', () => {
@@ -205,8 +205,8 @@ describe('Test MapMultiRegistry', () => {
         // Test execution
         const result = multiRegistry.getAll();
         expect(result).toHaveLength(3);
-        expect(e1.value.every(v => result.includes(v))).true;
-        expect(e2.value.every(v => result.includes(v))).true;
+        expect(e1.value.every(v => result.includes(v))).toBe(true);
+        expect(e2.value.every(v => result.includes(v))).toBe(true);
     });
 
     it('keys', () => {
@@ -219,7 +219,7 @@ describe('Test MapMultiRegistry', () => {
         // Test execution
         const result = multiRegistry.keys();
         expect(result.length).toBe(2);
-        expect(result.includes(e1.key)).true;
-        expect(result.includes(e2.key)).true;
+        expect(result.includes(e1.key)).toBe(true);
+        expect(result.includes(e2.key)).toBe(true);
     });
 });

--- a/packages/server/src/node/launch/socket-cli-parser.spec.ts
+++ b/packages/server/src/node/launch/socket-cli-parser.spec.ts
@@ -44,12 +44,12 @@ describe('test createCliParser', () => {
 
     it('parse - --no-consoleLog', () => {
         const result = parser.parse([...argv, '--no-consoleLog']);
-        expect(result.consoleLog).false;
+        expect(result.consoleLog).toBe(false);
     });
 
     it('parse - --fileLog', () => {
         const result = parser.parse([...argv, '--fileLog']);
-        expect(result.fileLog).true;
+        expect(result.fileLog).toBe(true);
     });
 
     it('parse - custom host name', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     devDependencies:
       '@eclipse-glsp/dev':
         specifier: next
-        version: 2.8.0-next.16(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
+        version: 2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
       '@types/node':
         specifier: 22.x
         version: 22.19.21
@@ -66,7 +66,7 @@ importers:
     dependencies:
       '@eclipse-glsp/protocol':
         specifier: next
-        version: 2.8.0-next.12(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        version: 2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
 
   packages/layout-elk:
     dependencies:
@@ -90,7 +90,7 @@ importers:
         version: link:../graph
       '@eclipse-glsp/protocol':
         specifier: next
-        version: 2.8.0-next.12(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        version: 2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       commander:
         specifier: ^14.0.0
         version: 14.0.3
@@ -168,21 +168,21 @@ packages:
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
-  '@eclipse-glsp/cli@2.8.0-next.16':
-    resolution: {integrity: sha512-PyIDa2YaXzXCiYEGEfFoDy0U6suclx8dLcX0DCoDQr4mPpfgU6H63zk9k+4FKr+u475XV3ch5kUPHMQVRv/Fag==}
+  '@eclipse-glsp/cli@2.8.0-next.19':
+    resolution: {integrity: sha512-t+PEnSqOjFXznmAexX7Ekc+jLUIqPlIkUnm1laWi/D9mFHo67KRQ7563qmrTn4Wi0NAsdWeXToFBxFxG6/PfaQ==}
     hasBin: true
 
-  '@eclipse-glsp/config-test@2.8.0-next.16':
-    resolution: {integrity: sha512-7ihYKqjTIbfv1mTvrFsGy43f3h0jHNX1RJprAV9bp9zth2hfFQN/Y4xB564EwquE+suRc9ZJJvzJj/HNBa7BRg==}
+  '@eclipse-glsp/config-test@2.8.0-next.19':
+    resolution: {integrity: sha512-kLTnX6MGyKvI9u6TxZek3AQaUcdI/TMuhDBwB0+zGma3lwuGSvXqmqkYDdXrGN5ntuYoq7sfZBuCy+67LO7SXQ==}
 
-  '@eclipse-glsp/config@2.8.0-next.16':
-    resolution: {integrity: sha512-qM1PeD9UxvwKAf3G3ImOYFee7IvAFfL4TzwxPmPLnIdB4dAj7wDCY6COBcifAQD+jDoSuXFniQPcaUnHZKjfig==}
+  '@eclipse-glsp/config@2.8.0-next.19':
+    resolution: {integrity: sha512-Jxb3Zq9pw1waIbBINTEy9+7clcB939bOW+Lo56GB38LBd4HkQX82/Gh0EZN7PZhMP/mCfo4J6XGOK0m7q7qbpg==}
 
-  '@eclipse-glsp/dev@2.8.0-next.16':
-    resolution: {integrity: sha512-WUNk3B6MLkM8HZND1FqyccwQZ7A/DfqUBDGAypjj3JYMiAOTZwseQXB8ea4Z/iCTfEmq3wnYapbnm25SwSoFSQ==}
+  '@eclipse-glsp/dev@2.8.0-next.19':
+    resolution: {integrity: sha512-Kairzb+bgxSVuBcVPBLxWNbJevMm3nYqbTY1WaY8RXjDCRSW03U50et2AgC2L/F8I1gmJGZLfMF4BhxJzehOIg==}
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.16':
-    resolution: {integrity: sha512-FDWiHnTj/vv1+tBg7kNoUbsBm8OMIUhEsQfTNw53lqaXeNdcHRfv5Aur6tArRWbu0EoeEsqe79te3evP/tzReQ==}
+  '@eclipse-glsp/eslint-config@2.8.0-next.19':
+    resolution: {integrity: sha512-QlXER0UYOaYT7WpzYpuHbLgjaeKTTjd0USddgvvuWneIwvsRRjaXk9QI0RKeCIKvJHjpzPOFsmW8RTjzp/EMhw==}
     peerDependencies:
       '@eslint/js': ^10.0.1
       '@stylistic/eslint-plugin': ^5.10.0
@@ -190,17 +190,16 @@ packages:
       eslint: ^10.5.0
       eslint-config-prettier: ^10.0.0
       eslint-import-resolver-typescript: ^4.0.0
-      eslint-plugin-chai-friendly: ^1.0.0
       eslint-plugin-import-x: ^4.16.2
       eslint-plugin-no-null: ^1.0.2
       globals: ^17.6.0
       typescript-eslint: ^8.0.0
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.16':
-    resolution: {integrity: sha512-ZdYR+vVDBlbpiLwQhvPAFktPQMB5hvi15g4hsGBALwCWa7v5FYfzAahTgoH5imCf0zJNXt/VmbsonK7eWCBaEA==}
+  '@eclipse-glsp/prettier-config@2.8.0-next.19':
+    resolution: {integrity: sha512-pBLY7CQYHl0pAwSTiNPr4j182sSi0LH9ZwL+Ka0EhvXMMxUfvPMaEmKFi5nXuxVigeOFpRcTaRyuJU0LH15AqA==}
 
-  '@eclipse-glsp/protocol@2.8.0-next.12':
-    resolution: {integrity: sha512-asaLdnqtREilxO8+5ObuokYS8lh2EsbUlBW5LXIAtVGGrEwbyGMZyetq3nG+bSqNaDwp2qpkfAuMp8uCm6yEgg==}
+  '@eclipse-glsp/protocol@2.8.0-next.13':
+    resolution: {integrity: sha512-hS9APz4RFmlFmCaucnHRbWgbQSfgbNBYQGPNQYy8esVzHwB1MQ8T3NBcnWmHBU+smrXronHYtZcAfOtLIw0dlA==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
@@ -210,13 +209,13 @@ packages:
       reflect-metadata:
         optional: true
 
-  '@eclipse-glsp/ts-config@2.8.0-next.16':
-    resolution: {integrity: sha512-0iLQOrjar/75XDYJjeLlIMBeWStLwf78wqypi+oTAfHpSliGd6hWSR8mHIA9G9YQNHrOZWxPgXI5ISJ6sHT14Q==}
+  '@eclipse-glsp/ts-config@2.8.0-next.19':
+    resolution: {integrity: sha512-zH7UW1+upPxvGljLMTuOP+S7yfXtxyvDcXnkc+iPWtzZORzcLm7IZRYfzoC6EKx45cllyasiLwV5ebhk6a/QOw==}
     peerDependencies:
       typescript: '>=5.5'
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.16':
-    resolution: {integrity: sha512-gK/Unmg+lq9OYTyBxkYsY8H56FxhVrEa1NogvruqLg5HKkJGdNLP4j5DFACCq/jdnVvcfdCHM4Dx+nr+WM69jw==}
+  '@eclipse-glsp/vitest-config@2.8.0-next.19':
+    resolution: {integrity: sha512-Kq2VLBCTbp2keeNnNK6Io06iTSepzsQ/Ql3FCrXsEMyDziYYKsPsmZ1wbMbCWFoziQokWzTf4pkTcwVCymPWCQ==}
     peerDependencies:
       '@vitest/coverage-v8': '>=4.0.0'
       vitest: '>=4.0.0'
@@ -1073,12 +1072,6 @@ packages:
         optional: true
       eslint-plugin-import-x:
         optional: true
-
-  eslint-plugin-chai-friendly@1.2.1:
-    resolution: {integrity: sha512-mV3EOJLDr8+L+LS8uCkP711fnNHz+4PsmPyz18xwkvjJwfLRlnx0Eu6CFnb5B+dW5ahoav2jVer2KFYsmIuv3A==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      eslint: '>=3.0.0'
 
   eslint-plugin-import-x@4.16.2:
     resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
@@ -2012,11 +2005,11 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@eclipse-glsp/cli@2.8.0-next.16': {}
+  '@eclipse-glsp/cli@2.8.0-next.19': {}
 
-  '@eclipse-glsp/config-test@2.8.0-next.16(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
+  '@eclipse-glsp/config-test@2.8.0-next.19(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
     dependencies:
-      '@eclipse-glsp/vitest-config': 2.8.0-next.16(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
+      '@eclipse-glsp/vitest-config': 2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
     transitivePeerDependencies:
@@ -2034,18 +2027,17 @@ snapshots:
       - msw
       - vite
 
-  '@eclipse-glsp/config@2.8.0-next.16(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)':
+  '@eclipse-glsp/config@2.8.0-next.19(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@eclipse-glsp/eslint-config': 2.8.0-next.16(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-chai-friendly@1.2.1(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))
-      '@eclipse-glsp/prettier-config': 2.8.0-next.16(prettier@3.8.4)
-      '@eclipse-glsp/ts-config': 2.8.0-next.16(typescript@5.9.3)
+      '@eclipse-glsp/eslint-config': 2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))
+      '@eclipse-glsp/prettier-config': 2.8.0-next.19(prettier@3.8.4)
+      '@eclipse-glsp/ts-config': 2.8.0-next.19(typescript@5.9.3)
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
       '@tony.ganchev/eslint-plugin-header': 3.4.4(eslint@10.5.0)
       eslint: 10.5.0
       eslint-config-prettier: 10.1.8(eslint@10.5.0)
       eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
-      eslint-plugin-chai-friendly: 1.2.1(eslint@10.5.0)
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
       eslint-plugin-no-null: 1.0.2(eslint@10.5.0)
       globals: 17.6.0
@@ -2060,11 +2052,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eclipse-glsp/dev@2.8.0-next.16(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
+  '@eclipse-glsp/dev@2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
     dependencies:
-      '@eclipse-glsp/cli': 2.8.0-next.16
-      '@eclipse-glsp/config': 2.8.0-next.16(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
-      '@eclipse-glsp/config-test': 2.8.0-next.16(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
+      '@eclipse-glsp/cli': 2.8.0-next.19
+      '@eclipse-glsp/config': 2.8.0-next.19(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@eclipse-glsp/config-test': 2.8.0-next.19(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@opentelemetry/api'
@@ -2086,7 +2078,7 @@ snapshots:
       - typescript
       - vite
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.16(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-chai-friendly@1.2.1(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))':
+  '@eclipse-glsp/eslint-config@2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
@@ -2094,19 +2086,18 @@ snapshots:
       eslint: 10.5.0
       eslint-config-prettier: 10.1.8(eslint@10.5.0)
       eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0)
-      eslint-plugin-chai-friendly: 1.2.1(eslint@10.5.0)
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
       eslint-plugin-no-null: 1.0.2(eslint@10.5.0)
       globals: 17.6.0
       typescript-eslint: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.16(prettier@3.8.4)':
+  '@eclipse-glsp/prettier-config@2.8.0-next.19(prettier@3.8.4)':
     dependencies:
       prettier-plugin-packagejson: 3.0.2(prettier@3.8.4)
     transitivePeerDependencies:
       - prettier
 
-  '@eclipse-glsp/protocol@2.8.0-next.12(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/protocol@2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
       sprotty-protocol: 1.4.0
       uuid: 14.0.0
@@ -2115,11 +2106,11 @@ snapshots:
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
 
-  '@eclipse-glsp/ts-config@2.8.0-next.16(typescript@5.9.3)':
+  '@eclipse-glsp/ts-config@2.8.0-next.19(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.16(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
+  '@eclipse-glsp/vitest-config@2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
@@ -2854,10 +2845,6 @@ snapshots:
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  eslint-plugin-chai-friendly@1.2.1(eslint@10.5.0):
-    dependencies:
-      eslint: 10.5.0
 
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0):
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

After the Vitest migration, a number of tests still used chai-style
assertions like `expect(x).true;`. These are silent no-ops — the property
access asserts nothing — and were masked by the test-file eslint overrides.

- Convert leftover chai-style assertions (`expect(x).true;` /
  `.false;`) to real Vitest matchers (`toBe(true)` / `toBe(false)`)
  across the server spec suite
- Remove the `*.spec` eslint overrides: the updated
  `@eclipse-glsp/eslint-config` enables core `no-unused-expressions`
  (which now catches such no-op assertions even in tests) and namespace
  checks pass cleanly, so both overrides are redundant

Also:
- Refresh `pnpm-lock.yaml` for the bumped `@eclipse-glsp/eslint-config`

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
