### PR TITLE
Update SECURITY.md to Eclipse security-handbook template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,34 @@
-# Eclipse GLSP Vulnerability Reporting Policy
+# Security Policy
 
-If you think or suspect that you have discovered a new security vulnerability in this project, please do not disclose it on GitHub, e.g. in an issue, a PR, or a discussion. Any such disclosure will be removed/deleted on sight, to promote orderly disclosure, as per the Eclipse Foundation Security Policy (1).
+This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
 
-Instead, please report any potential vulnerability to the Eclipse Foundation Security Team. Make sure to provide a concise description of the issue, a CWE, and other supporting information.
+## How To Report a Vulnerability
 
-(1) Eclipse Foundation Vulnerability Reporting Policy: <https://www.eclipse.org/security/policy.php>
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+
+Instead, report it using one of the following ways:
+
+* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+* Report a [vulnerability](https://github.com/eclipse-glsp/glsp-server-node/security/advisories/new) directly via private vulnerability reporting on GitHub
+
+You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
+
+This information will help us triage your report more quickly.
+
+## Supported Versions
+
+Eclipse GLSP components are released in lockstep. Security fixes and backports are only provided for the latest released version and the upcoming release. Older versions do not receive security updates.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Replaces the legacy "Eclipse GLSP Vulnerability Reporting Policy" with the standardized [eclipse-csi security-handbook](https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md) `SECURITY.md` template. The same change is applied across all GLSP repositories.

- Adopt the security-handbook template for coordinated vulnerability disclosure
- Add GitHub private vulnerability reporting alongside the Eclipse Foundation confidential issue tracker
- Add guidance on the information to include in a report
- Document the supported versions

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Documentation-only change. Review the rendered `SECURITY.md` and confirm the vulnerability-reporting links resolve.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

None.

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [ ] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
