### PR TITLE
GLSP-1727: Keep applying computed bounds when an entry cannot be applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Potentially Breaking Changes
 
+- [layout] Keep applying computed bounds when an individual entry cannot be applied [#149](https://github.com/eclipse-glsp/glsp-server-node/pull/149)
+    - `applyRoute` now returns `GEdge | undefined` instead of `GEdge`
+    - `applyElementAndBounds`, `applyAlignment` and `applyRoute` no longer throw for an element the index cannot resolve, they report it as not applied. `applyRoutingPoints` stays strict.
+
 ## [v2.7.0 - 01/06/2026](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v2.7.0)
 
 ### Changes

--- a/packages/server/src/common/features/layout/computed-bounds-action-handler.spec.ts
+++ b/packages/server/src/common/features/layout/computed-bounds-action-handler.spec.ts
@@ -1,0 +1,167 @@
+/********************************************************************************
+ * Copyright (c) 2026 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { GGraph, GNode } from '@eclipse-glsp/graph';
+import { Action, ComputedBoundsAction, DirtyStateChangeReason, LayoutOperation } from '@eclipse-glsp/protocol';
+import { Container, ContainerModule } from 'inversify';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LogLevel, Logger } from '../../utils/logger';
+import { GModelIndex } from '../model/gmodel-index';
+import { ModelState } from '../model/model-state';
+import { ModelSubmissionHandler } from '../model/model-submission-handler';
+import { ComputedBoundsActionHandler } from './computed-bounds-action-handler';
+
+const NODE_ID = 'node0';
+const UNKNOWN_ID = 'does-not-exist';
+
+class CapturingLogger extends Logger {
+    logLevel = LogLevel.debug;
+    caller = undefined;
+    readonly warnings: string[] = [];
+    readonly debugMessages: string[] = [];
+
+    info(): void {}
+
+    warn(message: string): void {
+        this.warnings.push(message);
+    }
+
+    error(): void {}
+
+    debug(message: string): void {
+        this.debugMessages.push(message);
+    }
+}
+
+class StubModelSubmissionHandler extends ModelSubmissionHandler {
+    submitted = false;
+
+    override async submitModelDirectly(_reason?: DirtyStateChangeReason, _layout?: LayoutOperation): Promise<Action[]> {
+        this.submitted = true;
+        return [];
+    }
+}
+
+function createRoot(): GGraph {
+    const node = new GNode();
+    node.id = NODE_ID;
+    node.type = 'node';
+    node.size = { width: 1, height: 1 };
+
+    const root = new GGraph();
+    root.id = 'root';
+    root.type = 'graph';
+    root.revision = 1;
+    root.children = [node];
+    return root;
+}
+
+describe('ComputedBoundsActionHandler', () => {
+    let root: GGraph;
+    let logger: CapturingLogger;
+    let submissionHandler: StubModelSubmissionHandler;
+    let handler: ComputedBoundsActionHandler;
+
+    beforeEach(() => {
+        root = createRoot();
+        const index = new GModelIndex();
+        index.indexRoot(root);
+        logger = new CapturingLogger();
+        submissionHandler = new StubModelSubmissionHandler();
+
+        const container = new Container();
+        container.load(
+            new ContainerModule(bind => {
+                bind(Logger).toConstantValue(logger);
+                bind(ModelSubmissionHandler).toConstantValue(submissionHandler);
+                bind(ModelState).toConstantValue({ root, index } as unknown as ModelState);
+            })
+        );
+        handler = container.resolve(ComputedBoundsActionHandler);
+    });
+
+    function computedBounds(...elementIds: string[]): ComputedBoundsAction {
+        return ComputedBoundsAction.create(
+            elementIds.map(elementId => ({ elementId, newSize: { width: 10, height: 20 } })),
+            { revision: root.revision }
+        );
+    }
+
+    function nodeSize(): { width: number; height: number } | undefined {
+        return (root.children[0] as GNode).size;
+    }
+
+    it('applies the reported bounds', async () => {
+        await handler.execute(computedBounds(NODE_ID));
+
+        expect(nodeSize()).toEqual({ width: 10, height: 20 });
+        expect(logger.warnings).toHaveLength(0);
+    });
+
+    it('still applies the remaining bounds if one element cannot be resolved', async () => {
+        await handler.execute(computedBounds(UNKNOWN_ID, NODE_ID));
+
+        expect(nodeSize()).toEqual({ width: 10, height: 20 });
+    });
+
+    it('reports the entry it skipped, naming the element', async () => {
+        await handler.execute(computedBounds(UNKNOWN_ID, NODE_ID));
+
+        expect(logger.warnings).toHaveLength(1);
+        expect(logger.warnings[0]).toContain(UNKNOWN_ID);
+        expect(logger.warnings[0]).toContain('bounds');
+    });
+
+    it('still submits the model if an entry was skipped', async () => {
+        await handler.execute(computedBounds(UNKNOWN_ID));
+
+        expect(submissionHandler.submitted).toBe(true);
+    });
+
+    it('skips a route that does not describe an edge', async () => {
+        const action = ComputedBoundsAction.create([], {
+            revision: root.revision,
+            routes: [{ elementId: NODE_ID, newRoutingPoints: [] }]
+        });
+
+        await handler.execute(action);
+
+        expect(logger.debugMessages).toHaveLength(1);
+        expect(logger.debugMessages[0]).toContain('route');
+        expect(submissionHandler.submitted).toBe(true);
+    });
+
+    it('does not warn about a route the client has not finished routing', async () => {
+        const action = ComputedBoundsAction.create([], {
+            revision: root.revision,
+            routes: [{ elementId: NODE_ID, newRoutingPoints: [] }]
+        });
+
+        await handler.execute(action);
+
+        expect(logger.warnings).toHaveLength(0);
+    });
+
+    it('ignores an action whose revision does not match the model', async () => {
+        const action = ComputedBoundsAction.create([{ elementId: NODE_ID, newSize: { width: 10, height: 20 } }], {
+            revision: root.revision! + 1
+        });
+
+        await handler.execute(action);
+
+        expect(nodeSize()).toEqual({ width: 1, height: 1 });
+        expect(submissionHandler.submitted).toBe(false);
+    });
+});

--- a/packages/server/src/common/features/layout/computed-bounds-action-handler.ts
+++ b/packages/server/src/common/features/layout/computed-bounds-action-handler.ts
@@ -14,10 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import { GModelRoot } from '@eclipse-glsp/graph';
-import { Action, ComputedBoundsAction, LayoutOperation, MaybePromise } from '@eclipse-glsp/protocol';
+import {
+    Action,
+    ComputedBoundsAction,
+    ElementAndAlignment,
+    ElementAndBounds,
+    ElementAndRoutingPoints,
+    LayoutOperation,
+    MaybePromise
+} from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import { ActionHandler } from '../../actions/action-handler';
 import { applyAlignment, applyElementAndBounds, applyRoute } from '../../utils/layout-util';
+import { Logger } from '../../utils/logger';
 import { ModelState } from '../model/model-state';
 import { ModelSubmissionHandler } from '../model/model-submission-handler';
 
@@ -34,6 +43,9 @@ export class ComputedBoundsActionHandler implements ActionHandler {
     @inject(ModelState)
     protected modelState: ModelState;
 
+    @inject(Logger)
+    protected logger: Logger;
+
     actionKinds = [ComputedBoundsAction.KIND];
     execute(action: ComputedBoundsAction): MaybePromise<Action[]> {
         const model = this.modelState.root;
@@ -48,11 +60,47 @@ export class ComputedBoundsActionHandler implements ActionHandler {
         return [];
     }
 
+    /**
+     * Applies everything the client computed for the given model.
+     *
+     * An entry that cannot be applied is skipped and logged rather than treated as an error.
+     */
     protected applyBounds(root: GModelRoot, action: ComputedBoundsAction): void {
+        this.applyElementBounds(action.bounds);
+        this.applyAlignments(action.alignments ?? []);
+        this.applyRoutes(action.routes ?? []);
+    }
+
+    protected applyElementBounds(allBounds: ElementAndBounds[]): void {
         const index = this.modelState.index;
-        action.bounds.forEach(bounds => applyElementAndBounds(bounds, index));
-        (action.alignments ?? []).forEach(alignment => applyAlignment(alignment, index));
-        (action.routes ?? []).forEach(route => applyRoute(route, index));
+        allBounds.forEach(bounds => {
+            if (!applyElementAndBounds(bounds, index)) {
+                this.logger.warn(`Skipped computed bounds of element '${bounds.elementId}'`);
+            }
+        });
+    }
+
+    protected applyAlignments(alignments: ElementAndAlignment[]): void {
+        const index = this.modelState.index;
+        alignments.forEach(alignment => {
+            if (!applyAlignment(alignment, index)) {
+                this.logger.warn(`Skipped computed alignment of element '${alignment.elementId}'`);
+            }
+        });
+    }
+
+    /**
+     * Applies the computed routes.
+     *
+     * A skipped route is logged at debug level, an edge the client has not finished routing yet is expected.
+     */
+    protected applyRoutes(routes: ElementAndRoutingPoints[]): void {
+        const index = this.modelState.index;
+        routes.forEach(route => {
+            if (!applyRoute(route, index)) {
+                this.logger.debug(`Skipped computed route of element '${route.elementId}'`);
+            }
+        });
     }
 
     priority?: number | undefined;

--- a/packages/server/src/common/utils/layout-util.ts
+++ b/packages/server/src/common/utils/layout-util.ts
@@ -25,11 +25,11 @@ import { GLSPServerError, getOrThrow } from './glsp-server-error';
  *
  * @param bounds The new bounds.
  * @param index  The model index.
- * @returns The changed element.
+ * @returns The changed element, or `undefined` if the bounds could not be applied to any element.
  */
 export function applyElementAndBounds(bounds: ElementAndBounds, index: GModelIndex): GBoundsAware | undefined {
-    const element = getOrThrow(index.get(bounds.elementId), 'Model element not found! ID: ' + bounds.elementId);
-    if (isGBoundsAware(element)) {
+    const element = index.find(bounds.elementId);
+    if (element && isGBoundsAware(element)) {
         if (bounds.newPosition !== undefined) {
             element.position = bounds.newPosition;
         }
@@ -44,11 +44,11 @@ export function applyElementAndBounds(bounds: ElementAndBounds, index: GModelInd
  *
  * @param alignment The new alignment.
  * @param index     The model index.
- * @returns The changed element.
+ * @returns The changed element, or `undefined` if the alignment could not be applied to any element.
  */
 export function applyAlignment(alignment: ElementAndAlignment, index: GModelIndex): GAlignable | undefined {
-    const element = getOrThrow(index.get(alignment.elementId), 'Model element not found! ID: ' + alignment.elementId);
-    if (isGAlignable(element)) {
+    const element = index.find(alignment.elementId);
+    if (element && isGAlignable(element)) {
         element.alignment = alignment.newAlignment;
         return element;
     }
@@ -56,19 +56,20 @@ export function applyAlignment(alignment: ElementAndAlignment, index: GModelInde
 }
 
 /**
- * Applies the new route to the model.
+ * Applies the new route to the model. A route needs at least a source and a target point to describe an edge.
  *
  * @param route The new route.
  * @param index The model index.
- * @returns The changed element.
+ * @returns The changed edge, or `undefined` if the route could not be applied to any edge.
  */
-export function applyRoute(route: ElementAndRoutingPoints, index: GModelIndex): GEdge {
+export function applyRoute(route: ElementAndRoutingPoints, index: GModelIndex): GEdge | undefined {
     const routingPoints = route.newRoutingPoints ?? [];
-    if (routingPoints.length < 2) {
-        throw new GLSPServerError('Invalid Route!');
+    const edge = index.findByClass(route.elementId, GEdge);
+    if (!edge || routingPoints.length < 2) {
+        return undefined;
     }
     // first and last point mark the source and target point
-    const edge = applyRoutingPoints(route, index);
+    edge.routingPoints = routingPoints;
     const edgeRoutingPoints = edge.routingPoints;
 
     const args = edge.args ?? {};


### PR DESCRIPTION
#### What it does

A single unresolvable element in a ComputedBoundsAction aborted the whole batch: the client had already measured every element, but one stale id threw and the server dropped the remaining bounds, alignments and routes along with the model update the client was waiting for.

- resolve elements via index.find / index.findByClass so an unknown id yields undefined instead of throwing
- report a route with fewer than two points as not applicable rather than as an error, a client may have nothing to report for an unmeasured edge yet
- log a skipped entry and still submit the model
- log skipped routes at debug, not warn, an edge the client has not finished routing is expected on the initial layout pass
- split the apply step into applyElementBounds, applyAlignments and applyRoutes so adopters can override one kind on its own
- leave applyRoutingPoints strict, an unknown id in ChangeRoutingPointsOperationHandler is a real error

applyRoute now returns GEdge | undefined; noted in the changelog under potentially breaking changes.

Relates to eclipse-glsp/glsp#1727

#### How to test

1. In the workflow example, add an element to the diagram root from a client-side feedback command without giving it the feedbackFeature.
2. Open the diagram, so the server issues a bounds request and the client reports the extra element back.
3. The server logs Could not retrieve element with id: … and the diagram never finishes loading.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
