### PR TITLE
GLSP-1729: Expose the bound address and accepted connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changes
 
+- [launch] Expose the address a `SocketServerLauncher` bound to via `listening` and `port`, so an embedder no longer has to parse the startup message to learn an OS-assigned port [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+- [launch] Add an `onConnection` event to `SocketServerLauncher` and `WebSocketServerLauncher`, so an embedder can observe accepted connections without reaching for the protected server field [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+- [launch] Release the server socket again when a restarted launcher is shut down [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+    - launchers now register what `shutdown` has to release in the new `registerDisposables` hook, called once per launch, rather than in their constructor
+
 ### Potentially Breaking Changes
 
 - [layout] Keep applying computed bounds when an individual entry cannot be applied [#149](https://github.com/eclipse-glsp/glsp-server-node/pull/149)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@
 
 ### Changes
 
-- [launch] Expose the address a `SocketServerLauncher` bound to via `listening` and `port`, so an embedder no longer has to parse the startup message to learn an OS-assigned port [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+- [launch] Expose the address a launcher bound to via `listening` and `port` on `JsonRpcGLSPServerLauncher`, so an embedder no longer has to parse the startup message to learn an OS-assigned port [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
 - [launch] Add an `onConnection` event to `SocketServerLauncher` and `WebSocketServerLauncher`, so an embedder can observe accepted connections without reaching for the protected server field [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+    - the web socket event carries the upgrade request next to the socket, which is the only place its headers and query are still available
 - [launch] Release the server socket again when a restarted launcher is shut down [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
-    - launchers now register what `shutdown` has to release in the new `registerDisposables` hook, called once per launch, rather than in their constructor
+    - `WebSocketServerLauncher` now also closes the HTTP server it mounts on, which `ws` leaves listening because it did not create it
 
 ### Potentially Breaking Changes
 
 - [layout] Keep applying computed bounds when an individual entry cannot be applied [#149](https://github.com/eclipse-glsp/glsp-server-node/pull/149)
     - `applyRoute` now returns `GEdge | undefined` instead of `GEdge`
     - `applyElementAndBounds`, `applyAlignment` and `applyRoute` no longer throw for an element the index cannot resolve, they report it as not applied. `applyRoutingPoints` stays strict.
+- [launch] Launchers register what `shutdown` has to release in the new `GLSPServerLauncher.registerDisposables` hook, called once per launch, rather than in their constructor [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
+    - A custom launcher that pushes into `toDispose` from its constructor keeps compiling but loses that cleanup after the first `shutdown`, because `dispose` empties the collection. Move those registrations into an override of `registerDisposables`.
 
 ## [v2.7.0 - 01/06/2026](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v2.7.0)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,22 +10,22 @@ If you think you have found a vulnerability in this repository, please report it
 
 Instead, report it using one of the following ways:
 
-* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
-* Report a [vulnerability](https://github.com/eclipse-glsp/glsp-server-node/security/advisories/new) directly via private vulnerability reporting on GitHub
+- Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+- Report a [vulnerability](https://github.com/eclipse-glsp/glsp-server-node/security/advisories/new) directly via private vulnerability reporting on GitHub
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
-* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-* Affected version(s)
-* Impact of the issue, including how an attacker might exploit the issue
-* Step-by-step instructions to reproduce the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Full paths of source file(s) related to the manifestation of the issue
-* Configuration required to reproduce the issue
-* Log files that are related to this issue (if possible)
-* Proof-of-concept or exploit code (if possible)
+- The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+- Affected version(s)
+- Impact of the issue, including how an attacker might exploit the issue
+- Step-by-step instructions to reproduce the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Full paths of source file(s) related to the manifestation of the issue
+- Configuration required to reproduce the issue
+- Log files that are related to this issue (if possible)
+- Proof-of-concept or exploit code (if possible)
 
 This information will help us triage your report more quickly.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,5 +96,5 @@ export default [
                 }
             ]
         }
-    },
+    }
 ];

--- a/packages/server/src/common/launch/glsp-server-launcher.ts
+++ b/packages/server/src/common/launch/glsp-server-launcher.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2023 STMicroelectronics and others.
+ * Copyright (c) 2022-2026 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/server/src/common/launch/glsp-server-launcher.ts
+++ b/packages/server/src/common/launch/glsp-server-launcher.ts
@@ -42,9 +42,20 @@ export abstract class GLSPServerLauncher<T> implements Disposable {
     start(startParams: T): MaybePromise<void> {
         if (!this.running) {
             this.running = true;
+            this.registerDisposables();
             return this.run(startParams);
         }
         this.logger.warn('Could not start launcher. Launcher is already running!');
+    }
+
+    /**
+     * Registers what {@link shutdown} has to release for the launch that is about to start.
+     *
+     * Called once per launch, because {@link dispose} empties the collection it registers into. A subclass that holds
+     * resources for the duration of a launch overrides this instead of registering them in its constructor.
+     */
+    protected registerDisposables(): void {
+        // nothing to release by default
     }
 
     protected abstract run(startParams: T): MaybePromise<void>;

--- a/packages/server/src/common/launch/jsonrpc-server-launcher.ts
+++ b/packages/server/src/common/launch/jsonrpc-server-launcher.ts
@@ -43,8 +43,8 @@ export abstract class JsonRpcGLSPServerLauncher<T> extends GLSPServerLauncher<T>
     protected serverInstances = new Map<jsonrpc.MessageConnection, JsonRpcServerInstance>();
     protected startupCompleteMessage = START_UP_COMPLETE_MSG;
 
-    constructor() {
-        super();
+    protected override registerDisposables(): void {
+        super.registerDisposables();
         this.toDispose.push(
             Disposable.create(() => {
                 this.serverInstances.forEach(instance => this.disposeServerInstance(instance));

--- a/packages/server/src/common/launch/jsonrpc-server-launcher.ts
+++ b/packages/server/src/common/launch/jsonrpc-server-launcher.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import {
+    Deferred,
     Disposable,
     GLSPClientProxy,
     GLSPServer,
@@ -23,6 +24,7 @@ import {
     configureClientConnection
 } from '@eclipse-glsp/protocol';
 import { Container, ContainerModule, inject, injectable } from 'inversify';
+import * as net from 'net';
 import * as jsonrpc from 'vscode-jsonrpc';
 import { Logger } from '../utils/logger';
 import { GLSPServerLauncher } from './glsp-server-launcher';
@@ -42,6 +44,91 @@ export abstract class JsonRpcGLSPServerLauncher<T> extends GLSPServerLauncher<T>
 
     protected serverInstances = new Map<jsonrpc.MessageConnection, JsonRpcServerInstance>();
     protected startupCompleteMessage = START_UP_COMPLETE_MSG;
+
+    protected listeningAddress = new Deferred<net.AddressInfo>();
+
+    /**
+     * Resolves with the address the server bound to once it is listening, and rejects if it never gets there.
+     *
+     * Launching with port `0` lets the operating system pick a free port, so the bound address is not necessarily the
+     * requested one. Settles once per launch and keeps that value, so use {@link port} for the current state. Reading
+     * this before {@link start} is fine, the promise handed out is the one that launch settles.
+     */
+    get listening(): Promise<net.AddressInfo> {
+        return this.listeningAddress.promise;
+    }
+
+    /**
+     * The port the server is currently listening on, or `undefined` if it is not.
+     *
+     * Await {@link listening} rather than polling this while the server is still starting up.
+     */
+    get port(): number | undefined {
+        const address = this.getServerSocket()?.address();
+        return address && typeof address !== 'string' ? address.port : undefined;
+    }
+
+    /**
+     * The socket that {@link port} reports on, or `undefined` before the first launch.
+     *
+     * A launcher that binds a socket overrides this, the default reports no address at all.
+     */
+    protected getServerSocket(): net.Server | undefined {
+        return undefined;
+    }
+
+    /**
+     * Arms {@link listening} for a launch.
+     *
+     * An unresolved promise is kept, so a caller that grabbed {@link listening} before {@link start} gets the one this
+     * launch settles. A settled one is replaced, so a restart is not handed the previous result.
+     */
+    protected resetListening(): void {
+        if (this.listeningAddress.state !== 'unresolved') {
+            this.listeningAddress = new Deferred<net.AddressInfo>();
+        }
+    }
+
+    /**
+     * Resolves {@link listening} with the address the given server bound to.
+     *
+     * @param server The server that reported itself as listening.
+     * @returns The bound address, or `undefined` if it cannot be used, in which case the launcher is shut down.
+     */
+    protected settleListening(server: net.Server): net.AddressInfo | undefined {
+        const addressInfo = server.address();
+        if (!addressInfo) {
+            this.failToListen('Could not resolve GLSP Server address info.');
+            return undefined;
+        }
+        if (typeof addressInfo === 'string') {
+            this.failToListen(`GLSP Server is unexpectedly listening to pipe or domain socket "${addressInfo}".`);
+            return undefined;
+        }
+        this.listeningAddress.resolve(addressInfo);
+        return addressInfo;
+    }
+
+    /**
+     * Invoked when the server socket fails, e.g. because the requested port is already in use.
+     *
+     * @param error The reason the socket failed.
+     */
+    protected handleError(error: Error): void {
+        this.failToListen(`GLSP server socket error. ${error.message}`, error);
+    }
+
+    /**
+     * Reports that the server will not accept requests, rejects {@link listening} and shuts the launcher down.
+     *
+     * @param message The reason the server is not usable.
+     * @param cause   The underlying error, if the reason was one.
+     */
+    protected failToListen(message: string, cause?: Error): void {
+        this.logger.error(`${message} Shutting down.`);
+        this.listeningAddress.reject(cause ?? new Error(message));
+        this.shutdown();
+    }
 
     protected override registerDisposables(): void {
         super.registerDisposables();

--- a/packages/server/src/node/launch/socket-server-launcher.spec.ts
+++ b/packages/server/src/node/launch/socket-server-launcher.spec.ts
@@ -19,51 +19,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Container } from 'inversify';
 import * as net from 'net';
 import { createAppModule } from '../di/app-module';
+import { waitForReachable } from '../test/port-util';
 import { defaultSocketLaunchOptions } from './socket-cli-parser';
 import { SocketServerLauncher } from './socket-server-launcher';
 
 const serverPort = 5008;
-
-function delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-/**
- * Resolves whether a TCP connection to the given port is currently accepted.
- *
- * The outcome is routed through the returned promise rather than asserted inside the socket event
- * callbacks on purpose: an assertion thrown from a detached socket listener escapes the test's
- * promise chain and surfaces as a Vitest "unhandled error" that fails the run *without* turning any
- * individual test red. Resolving/rejecting keeps every outcome attributable to this test.
- */
-function isReachable(port: number): Promise<boolean> {
-    return new Promise(resolve => {
-        const socket = new net.Socket();
-        socket.setTimeout(1000);
-        const finish = (reachable: boolean): void => {
-            socket.destroy();
-            resolve(reachable);
-        };
-        socket
-            .on('connect', () => finish(true))
-            .on('error', () => finish(false))
-            .on('timeout', () => finish(false))
-            .connect(port);
-    });
-}
-
-/** Polls until the port reaches the expected reachability, or fails the test once the deadline elapses. */
-async function waitForReachable(port: number, expected: boolean, deadlineMs = 5000): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < deadlineMs) {
-        if ((await isReachable(port)) === expected) {
-            return;
-        }
-
-        await delay(50);
-    }
-    expect.fail(`Port ${port} did not become ${expected ? 'reachable' : 'unreachable'} within ${deadlineMs}ms`);
-}
 
 function createLauncher(): SocketServerLauncher {
     const serverStub = {
@@ -106,6 +66,15 @@ describe('test SocketServerLauncher', () => {
         launcher.start({ port: serverPort });
 
         await expect(launcher.listening).resolves.toMatchObject({ port: serverPort });
+    });
+
+    it('resolves a promise that was grabbed before the launch', async () => {
+        launcher = createLauncher();
+        const listening = launcher.listening;
+
+        launcher.start({ port: serverPort });
+
+        await expect(listening).resolves.toMatchObject({ port: serverPort });
     });
 
     it('resolves the port the operating system assigned', async () => {

--- a/packages/server/src/node/launch/socket-server-launcher.spec.ts
+++ b/packages/server/src/node/launch/socket-server-launcher.spec.ts
@@ -65,6 +65,23 @@ async function waitForReachable(port: number, expected: boolean, deadlineMs = 50
     expect.fail(`Port ${port} did not become ${expected ? 'reachable' : 'unreachable'} within ${deadlineMs}ms`);
 }
 
+function createLauncher(): SocketServerLauncher {
+    const serverStub = {
+        initialize: vi.fn().mockResolvedValue({}),
+        initializeClientSession: vi.fn().mockResolvedValue(undefined),
+        disposeClientSession: vi.fn().mockResolvedValue(undefined),
+        process: vi.fn(),
+        shutdown: vi.fn(),
+        addListener: vi.fn().mockReturnValue(true),
+        removeListener: vi.fn().mockReturnValue(true)
+    } as unknown as GLSPServer;
+
+    const appContainer = new Container();
+    appContainer.load(createAppModule(defaultSocketLaunchOptions));
+    appContainer.bind(GLSPServer).toConstantValue(serverStub);
+    return appContainer.resolve(SocketServerLauncher);
+}
+
 describe('test SocketServerLauncher', () => {
     let launcher: SocketServerLauncher | undefined;
 
@@ -74,25 +91,119 @@ describe('test SocketServerLauncher', () => {
     });
 
     it('starts and stops', async () => {
-        const serverStub = {
-            initialize: vi.fn().mockResolvedValue({}),
-            initializeClientSession: vi.fn().mockResolvedValue(undefined),
-            disposeClientSession: vi.fn().mockResolvedValue(undefined),
-            process: vi.fn(),
-            shutdown: vi.fn(),
-            addListener: vi.fn().mockReturnValue(true),
-            removeListener: vi.fn().mockReturnValue(true)
-        } as unknown as GLSPServer;
-
-        const appContainer = new Container();
-        appContainer.load(createAppModule(defaultSocketLaunchOptions));
-        appContainer.bind(GLSPServer).toConstantValue(serverStub);
-        launcher = appContainer.resolve(SocketServerLauncher);
+        launcher = createLauncher();
 
         launcher.start({ port: serverPort });
         await waitForReachable(serverPort, true);
 
         launcher.shutdown();
         await waitForReachable(serverPort, false);
+    });
+
+    it('resolves the address it is listening on', async () => {
+        launcher = createLauncher();
+
+        launcher.start({ port: serverPort });
+
+        await expect(launcher.listening).resolves.toMatchObject({ port: serverPort });
+    });
+
+    it('resolves the port the operating system assigned', async () => {
+        launcher = createLauncher();
+
+        launcher.start({ port: 0 });
+        const address = await launcher.listening;
+
+        expect(address.port).toBeGreaterThan(0);
+        expect(launcher.port).toBe(address.port);
+        await waitForReachable(address.port, true);
+    });
+
+    it('reports no port unless it is listening', async () => {
+        launcher = createLauncher();
+        expect(launcher.port).toBeUndefined();
+
+        launcher.start({ port: serverPort });
+        await launcher.listening;
+        expect(launcher.port).toBe(serverPort);
+
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+        expect(launcher.port).toBeUndefined();
+    });
+
+    it('notifies observers of every accepted connection', async () => {
+        launcher = createLauncher();
+        const accepted: net.Socket[] = [];
+        launcher.onConnection(socket => accepted.push(socket));
+
+        launcher.start({ port: serverPort });
+        await launcher.listening;
+
+        const client = net.createConnection({ port: serverPort });
+        try {
+            await new Promise<void>((resolve, reject) => {
+                client.on('connect', () => resolve());
+                client.on('error', reject);
+            });
+            await vi.waitFor(() => expect(accepted).toHaveLength(1));
+        } finally {
+            client.destroy();
+        }
+    });
+
+    it('rejects if the port is already in use', async () => {
+        const blocker = net.createServer();
+        await new Promise<void>(resolve => blocker.listen(serverPort, () => resolve()));
+        try {
+            launcher = createLauncher();
+
+            // `start` reports the same failure, so it is awaited here as well to keep every rejection handled
+            const stopped = Promise.resolve(launcher.start({ port: serverPort }));
+
+            await expect(launcher.listening).rejects.toThrow();
+            await expect(stopped).rejects.toThrow();
+        } finally {
+            await new Promise<void>(resolve => blocker.close(() => resolve()));
+        }
+    });
+
+    it('releases the server socket again when a restarted launcher is shut down', async () => {
+        launcher = createLauncher();
+
+        launcher.start({ port: serverPort });
+        await waitForReachable(serverPort, true);
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+
+        launcher.start({ port: serverPort });
+        await waitForReachable(serverPort, true);
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+    });
+
+    it('keeps notifying observers across a restart', async () => {
+        launcher = createLauncher();
+        const accepted: net.Socket[] = [];
+        launcher.onConnection(socket => accepted.push(socket));
+
+        launcher.start({ port: serverPort });
+        await launcher.listening;
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+
+        launcher.start({ port: serverPort });
+        await launcher.listening;
+
+        const client = net.createConnection({ port: serverPort });
+        try {
+            await new Promise<void>((resolve, reject) => {
+                client.on('connect', () => resolve());
+                client.on('error', reject);
+            });
+            await vi.waitFor(() => expect(accepted).toHaveLength(1));
+        } finally {
+            client.destroy();
+        }
     });
 });

--- a/packages/server/src/node/launch/socket-server-launcher.ts
+++ b/packages/server/src/node/launch/socket-server-launcher.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022-2024 STMicroelectronics and others.
+ * Copyright (c) 2022-2026 STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Deferred, Disposable, Emitter, Event } from '@eclipse-glsp/protocol';
+import { Disposable, Emitter } from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
 import * as jsonrpc from 'vscode-jsonrpc/node';
@@ -24,9 +24,7 @@ import { Logger } from '../../common/utils/logger';
 export class SocketServerLauncher extends JsonRpcGLSPServerLauncher<net.TcpSocketConnectOpts> {
     @inject(Logger) protected override logger: Logger;
 
-    protected netServer: net.Server;
-
-    protected listeningAddress = new Deferred<net.AddressInfo>();
+    protected netServer?: net.Server;
 
     protected onConnectionEmitter = new Emitter<net.Socket>();
 
@@ -36,49 +34,32 @@ export class SocketServerLauncher extends JsonRpcGLSPServerLauncher<net.TcpSocke
      * A listener must not consume the socket. Subscribe before {@link start} to observe the first connection; the
      * subscription outlives an individual launch and is disposed by the caller.
      */
-    get onConnection(): Event<net.Socket> {
-        return this.onConnectionEmitter.event;
-    }
+    readonly onConnection = this.onConnectionEmitter.event;
 
-    /**
-     * Resolves with the address the server bound to once it is listening, and rejects if it never gets there.
-     *
-     * Launching with port `0` lets the operating system pick a free port, so the bound address is not necessarily the
-     * requested one. Settles once per launch and keeps that value, so use {@link port} for the current state.
-     */
-    get listening(): Promise<net.AddressInfo> {
-        return this.listeningAddress.promise;
-    }
-
-    /**
-     * The port the server is currently listening on, or `undefined` if it is not.
-     *
-     * Await {@link listening} rather than polling this while the server is still starting up.
-     */
-    get port(): number | undefined {
-        const address = this.netServer?.address();
-        return address && typeof address !== 'string' ? address.port : undefined;
+    protected override getServerSocket(): net.Server | undefined {
+        return this.netServer;
     }
 
     protected override registerDisposables(): void {
         super.registerDisposables();
         this.toDispose.push(
             Disposable.create(() => {
-                this.netServer.close();
+                this.netServer?.close();
             })
         );
     }
 
     protected run(opts: net.TcpSocketConnectOpts): Promise<void> {
         this.resetListening();
-        this.netServer = net.createServer(socket => this.acceptConnection(socket));
+        const netServer = net.createServer(socket => this.acceptConnection(socket));
+        this.netServer = netServer;
 
-        this.netServer.listen(opts.port, opts.host);
-        this.netServer.on('listening', () => this.onListening());
-        this.netServer.on('error', error => this.onError(error));
+        netServer.listen(opts.port, opts.host);
+        netServer.on('listening', () => this.handleListening(netServer));
+        netServer.on('error', error => this.handleError(error));
         return new Promise((resolve, reject) => {
-            this.netServer.on('close', () => resolve(undefined));
-            this.netServer.on('error', error => reject(error));
+            netServer.on('close', () => resolve(undefined));
+            netServer.on('error', error => reject(error));
         });
     }
 
@@ -92,50 +73,20 @@ export class SocketServerLauncher extends JsonRpcGLSPServerLauncher<net.TcpSocke
         this.createServerInstance(this.createConnection(socket));
     }
 
-    /** Arms {@link listening} for a launch, so a settled promise is never handed to the next one. */
-    protected resetListening(): void {
-        this.listeningAddress = new Deferred<net.AddressInfo>();
-        // Nobody is obliged to consume `listening`, so pre-handle the rejection of a launch whose failure is not awaited.
-        this.listeningAddress.promise.catch(() => undefined);
-    }
-
-    /** Reports the server as ready and resolves {@link listening}, or fails if the bound address cannot be used. */
-    protected onListening(): void {
-        const addressInfo = this.netServer.address();
+    /**
+     * Reports the server as ready and resolves {@link listening}.
+     *
+     * @param server The server that reported itself as listening.
+     */
+    protected handleListening(server: net.Server): void {
+        const addressInfo = this.settleListening(server);
         if (!addressInfo) {
-            this.failToListen('Could not resolve GLSP Server address info.');
-            return;
-        }
-        if (typeof addressInfo === 'string') {
-            this.failToListen(`GLSP Server is unexpectedly listening to pipe or domain socket "${addressInfo}".`);
             return;
         }
         this.logger.info(`The GLSP server is ready to accept new client requests on port: ${addressInfo.port}`);
         // Print a message to the output stream that indicates that the start is completed.
         // This indicates to the client that the server process is ready (in an embedded scenario).
         console.log(this.startupCompleteMessage.concat(addressInfo.port.toString()));
-        this.listeningAddress.resolve(addressInfo);
-    }
-
-    /**
-     * Invoked when the server socket fails, e.g. because the requested port is already in use.
-     *
-     * @param error The reason the socket failed.
-     */
-    protected onError(error: Error): void {
-        this.failToListen(`GLSP server socket error. ${error.message}`, error);
-    }
-
-    /**
-     * Reports that the server will not accept requests, rejects {@link listening} and shuts the launcher down.
-     *
-     * @param message The reason the server is not usable.
-     * @param cause   The underlying error, if the reason was one.
-     */
-    protected failToListen(message: string, cause?: Error): void {
-        this.logger.error(`${message} Shutting down.`);
-        this.listeningAddress.reject(cause ?? new Error(message));
-        this.shutdown();
     }
 
     protected createConnection(socket: net.Socket): jsonrpc.MessageConnection {

--- a/packages/server/src/node/launch/socket-server-launcher.ts
+++ b/packages/server/src/node/launch/socket-server-launcher.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Disposable } from '@eclipse-glsp/protocol';
+import { Deferred, Disposable, Emitter, Event } from '@eclipse-glsp/protocol';
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
 import * as jsonrpc from 'vscode-jsonrpc/node';
@@ -26,8 +26,42 @@ export class SocketServerLauncher extends JsonRpcGLSPServerLauncher<net.TcpSocke
 
     protected netServer: net.Server;
 
-    constructor() {
-        super();
+    protected listeningAddress = new Deferred<net.AddressInfo>();
+
+    protected onConnectionEmitter = new Emitter<net.Socket>();
+
+    /**
+     * Fires for every socket the server accepts, before the JSON-RPC connection is built on it.
+     *
+     * A listener must not consume the socket. Subscribe before {@link start} to observe the first connection; the
+     * subscription outlives an individual launch and is disposed by the caller.
+     */
+    get onConnection(): Event<net.Socket> {
+        return this.onConnectionEmitter.event;
+    }
+
+    /**
+     * Resolves with the address the server bound to once it is listening, and rejects if it never gets there.
+     *
+     * Launching with port `0` lets the operating system pick a free port, so the bound address is not necessarily the
+     * requested one. Settles once per launch and keeps that value, so use {@link port} for the current state.
+     */
+    get listening(): Promise<net.AddressInfo> {
+        return this.listeningAddress.promise;
+    }
+
+    /**
+     * The port the server is currently listening on, or `undefined` if it is not.
+     *
+     * Await {@link listening} rather than polling this while the server is still starting up.
+     */
+    get port(): number | undefined {
+        const address = this.netServer?.address();
+        return address && typeof address !== 'string' ? address.port : undefined;
+    }
+
+    protected override registerDisposables(): void {
+        super.registerDisposables();
         this.toDispose.push(
             Disposable.create(() => {
                 this.netServer.close();
@@ -36,34 +70,72 @@ export class SocketServerLauncher extends JsonRpcGLSPServerLauncher<net.TcpSocke
     }
 
     protected run(opts: net.TcpSocketConnectOpts): Promise<void> {
-        this.netServer = net.createServer(socket => {
-            const connection = this.createConnection(socket);
-            this.createServerInstance(connection);
-        });
+        this.resetListening();
+        this.netServer = net.createServer(socket => this.acceptConnection(socket));
 
         this.netServer.listen(opts.port, opts.host);
-        this.netServer.on('listening', () => {
-            const addressInfo = this.netServer.address();
-            if (!addressInfo) {
-                this.logger.error('Could not resolve GLSP Server address info. Shutting down.');
-                this.shutdown();
-                return;
-            } else if (typeof addressInfo === 'string') {
-                this.logger.error(`GLSP Server is unexpectedly listening to pipe or domain socket "${addressInfo}". Shutting down.`);
-                this.shutdown();
-                return;
-            }
-            const currentPort = addressInfo.port;
-            this.logger.info(`The GLSP server is ready to accept new client requests on port: ${currentPort}`);
-            // Print a message to the output stream that indicates that the start is completed.
-            // This indicates to the client that the server process is ready (in an embedded scenario).
-            console.log(this.startupCompleteMessage.concat(currentPort.toString()));
-        });
-        this.netServer.on('error', () => this.shutdown());
+        this.netServer.on('listening', () => this.onListening());
+        this.netServer.on('error', error => this.onError(error));
         return new Promise((resolve, reject) => {
             this.netServer.on('close', () => resolve(undefined));
             this.netServer.on('error', error => reject(error));
         });
+    }
+
+    /**
+     * Takes up a socket the server accepted. Observers are notified before the socket is read from.
+     *
+     * @param socket The accepted socket.
+     */
+    protected acceptConnection(socket: net.Socket): void {
+        this.onConnectionEmitter.fire(socket);
+        this.createServerInstance(this.createConnection(socket));
+    }
+
+    /** Arms {@link listening} for a launch, so a settled promise is never handed to the next one. */
+    protected resetListening(): void {
+        this.listeningAddress = new Deferred<net.AddressInfo>();
+        // Nobody is obliged to consume `listening`, so pre-handle the rejection of a launch whose failure is not awaited.
+        this.listeningAddress.promise.catch(() => undefined);
+    }
+
+    /** Reports the server as ready and resolves {@link listening}, or fails if the bound address cannot be used. */
+    protected onListening(): void {
+        const addressInfo = this.netServer.address();
+        if (!addressInfo) {
+            this.failToListen('Could not resolve GLSP Server address info.');
+            return;
+        }
+        if (typeof addressInfo === 'string') {
+            this.failToListen(`GLSP Server is unexpectedly listening to pipe or domain socket "${addressInfo}".`);
+            return;
+        }
+        this.logger.info(`The GLSP server is ready to accept new client requests on port: ${addressInfo.port}`);
+        // Print a message to the output stream that indicates that the start is completed.
+        // This indicates to the client that the server process is ready (in an embedded scenario).
+        console.log(this.startupCompleteMessage.concat(addressInfo.port.toString()));
+        this.listeningAddress.resolve(addressInfo);
+    }
+
+    /**
+     * Invoked when the server socket fails, e.g. because the requested port is already in use.
+     *
+     * @param error The reason the socket failed.
+     */
+    protected onError(error: Error): void {
+        this.failToListen(`GLSP server socket error. ${error.message}`, error);
+    }
+
+    /**
+     * Reports that the server will not accept requests, rejects {@link listening} and shuts the launcher down.
+     *
+     * @param message The reason the server is not usable.
+     * @param cause   The underlying error, if the reason was one.
+     */
+    protected failToListen(message: string, cause?: Error): void {
+        this.logger.error(`${message} Shutting down.`);
+        this.listeningAddress.reject(cause ?? new Error(message));
+        this.shutdown();
     }
 
     protected createConnection(socket: net.Socket): jsonrpc.MessageConnection {

--- a/packages/server/src/node/launch/websocket-server-launcher.spec.ts
+++ b/packages/server/src/node/launch/websocket-server-launcher.spec.ts
@@ -1,0 +1,110 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { GLSPServer } from '@eclipse-glsp/protocol';
+import { Container } from 'inversify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebSocket } from 'ws';
+import { createAppModule } from '../di/app-module';
+import { waitForReachable } from '../test/port-util';
+import { defaultLaunchOptions } from './cli-parser';
+import { AcceptedWebSocket, WebSocketServerLauncher } from './websocket-server-launcher';
+
+const serverPort = 5009;
+const serverPath = 'test';
+
+function createLauncher(): WebSocketServerLauncher {
+    const serverStub = {
+        initialize: vi.fn().mockResolvedValue({}),
+        initializeClientSession: vi.fn().mockResolvedValue(undefined),
+        disposeClientSession: vi.fn().mockResolvedValue(undefined),
+        process: vi.fn(),
+        shutdown: vi.fn(),
+        addListener: vi.fn().mockReturnValue(true),
+        removeListener: vi.fn().mockReturnValue(true)
+    } as unknown as GLSPServer;
+
+    const appContainer = new Container();
+    appContainer.load(createAppModule(defaultLaunchOptions));
+    appContainer.bind(GLSPServer).toConstantValue(serverStub);
+    return appContainer.resolve(WebSocketServerLauncher);
+}
+
+function connect(query = ''): WebSocket {
+    return new WebSocket(`ws://localhost:${serverPort}/${serverPath}${query}`);
+}
+
+describe('test WebSocketServerLauncher', () => {
+    let launcher: WebSocketServerLauncher | undefined;
+
+    afterEach(() => {
+        launcher?.shutdown();
+        launcher = undefined;
+    });
+
+    it('resolves the address it is listening on', async () => {
+        launcher = createLauncher();
+        const listening = launcher.listening;
+
+        launcher.start({ port: serverPort, path: serverPath });
+
+        await expect(listening).resolves.toMatchObject({ port: serverPort });
+        expect(launcher.port).toBe(serverPort);
+    });
+
+    it('releases the server socket again when a restarted launcher is shut down', async () => {
+        launcher = createLauncher();
+
+        launcher.start({ port: serverPort, path: serverPath });
+        await waitForReachable(serverPort, true);
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+
+        launcher.start({ port: serverPort, path: serverPath });
+        await waitForReachable(serverPort, true);
+        launcher.shutdown();
+        await waitForReachable(serverPort, false);
+    });
+
+    it('releases the server socket when shut down while still starting up', async () => {
+        launcher = createLauncher();
+
+        launcher.start({ port: serverPort, path: serverPath });
+        launcher.shutdown();
+
+        await waitForReachable(serverPort, false);
+    });
+
+    it('notifies observers of every accepted connection with its upgrade request', async () => {
+        launcher = createLauncher();
+        const accepted: AcceptedWebSocket[] = [];
+        launcher.onConnection(connection => accepted.push(connection));
+
+        launcher.start({ port: serverPort, path: serverPath });
+        await launcher.listening;
+
+        const client = connect('?client=42');
+        try {
+            await new Promise<void>((resolve, reject) => {
+                client.on('open', () => resolve());
+                client.on('error', reject);
+            });
+            await vi.waitFor(() => expect(accepted).toHaveLength(1));
+            expect(accepted[0].request.url).toContain('client=42');
+        } finally {
+            client.close();
+        }
+    });
+});

--- a/packages/server/src/node/launch/websocket-server-launcher.ts
+++ b/packages/server/src/node/launch/websocket-server-launcher.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { createWebSocketConnection, Disposable, MaybePromise, WebSocketWrapper } from '@eclipse-glsp/protocol';
+import { createWebSocketConnection, Disposable, Emitter, Event, MaybePromise, WebSocketWrapper } from '@eclipse-glsp/protocol';
 import * as http from 'http';
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
@@ -50,8 +50,20 @@ export class WebSocketServerLauncher extends JsonRpcGLSPServerLauncher<WebSocket
 
     protected server: Server;
 
-    constructor() {
-        super();
+    protected onConnectionEmitter = new Emitter<WebSocket>();
+
+    /**
+     * Fires for every web socket the server accepts, before the JSON-RPC connection is built on it.
+     *
+     * A listener must not consume the socket. Subscribe before {@link start} to observe the first connection; the
+     * subscription outlives an individual launch and is disposed by the caller.
+     */
+    get onConnection(): Event<WebSocket> {
+        return this.onConnectionEmitter.event;
+    }
+
+    protected override registerDisposables(): void {
+        super.registerDisposables();
         this.toDispose.push(
             Disposable.create(() => {
                 this.server.close();
@@ -66,15 +78,22 @@ export class WebSocketServerLauncher extends JsonRpcGLSPServerLauncher<WebSocket
         this.logger.info(`The GLSP Websocket launcher is ready to accept new client requests on endpoint '${endpoint}'`);
         console.log(this.startupCompleteMessage.concat(resolvedOptions.port.toString()));
 
-        this.server.on('connection', (ws, req) => {
-            const connection = this.createConnection(ws);
-            this.createServerInstance(connection);
-        });
+        this.server.on('connection', ws => this.acceptConnection(ws));
 
         return new Promise((resolve, reject) => {
             this.server.on('close', () => resolve(undefined));
             this.server.on('error', error => reject(error));
         });
+    }
+
+    /**
+     * Takes up a web socket the server accepted. Observers are notified before the socket is read from.
+     *
+     * @param socket The accepted web socket.
+     */
+    protected acceptConnection(socket: WebSocket): void {
+        this.onConnectionEmitter.fire(socket);
+        this.createServerInstance(this.createConnection(socket));
     }
 
     protected createConnection(socket: WebSocket): jsonrpc.MessageConnection {

--- a/packages/server/src/node/launch/websocket-server-launcher.ts
+++ b/packages/server/src/node/launch/websocket-server-launcher.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 EclipseSource and others.
+ * Copyright (c) 2023-2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { createWebSocketConnection, Disposable, Emitter, Event, MaybePromise, WebSocketWrapper } from '@eclipse-glsp/protocol';
+import { createWebSocketConnection, Disposable, Emitter, MaybePromise, WebSocketWrapper } from '@eclipse-glsp/protocol';
 import * as http from 'http';
 import { inject, injectable } from 'inversify';
 import * as net from 'net';
 import * as jsonrpc from 'vscode-jsonrpc';
-import { Server, WebSocket } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 import { JsonRpcGLSPServerLauncher } from '../../common/launch/jsonrpc-server-launcher';
 import { Logger } from '../../common/utils/logger';
 
@@ -41,6 +41,13 @@ export interface WebsocketConnectionData {
     connection: jsonrpc.MessageConnection;
 }
 
+/** An accepted web socket together with the upgrade request it was negotiated with. */
+export interface AcceptedWebSocket {
+    socket: WebSocket;
+    /** The handshake request, the only place where its headers and query are still available. */
+    request: http.IncomingMessage;
+}
+
 const STATUS_UPGRADE_REQUIRED = 426;
 
 @injectable()
@@ -48,9 +55,16 @@ export class WebSocketServerLauncher extends JsonRpcGLSPServerLauncher<WebSocket
     @inject(Logger)
     protected override logger: Logger;
 
-    protected server: Server;
+    protected server?: WebSocketServer;
 
-    protected onConnectionEmitter = new Emitter<WebSocket>();
+    /**
+     * The HTTP server the web socket server is mounted on.
+     *
+     * Held separately because `ws` only closes an HTTP server it created itself, so releasing the socket is up to us.
+     */
+    protected httpServer?: http.Server;
+
+    protected onConnectionEmitter = new Emitter<AcceptedWebSocket>();
 
     /**
      * Fires for every web socket the server accepts, before the JSON-RPC connection is built on it.
@@ -58,41 +72,66 @@ export class WebSocketServerLauncher extends JsonRpcGLSPServerLauncher<WebSocket
      * A listener must not consume the socket. Subscribe before {@link start} to observe the first connection; the
      * subscription outlives an individual launch and is disposed by the caller.
      */
-    get onConnection(): Event<WebSocket> {
-        return this.onConnectionEmitter.event;
+    readonly onConnection = this.onConnectionEmitter.event;
+
+    protected override getServerSocket(): net.Server | undefined {
+        return this.httpServer;
     }
 
     protected override registerDisposables(): void {
         super.registerDisposables();
         this.toDispose.push(
             Disposable.create(() => {
-                this.server.close();
+                this.server?.close();
+                // `ws` leaves an HTTP server it did not create itself listening, so close ours explicitly.
+                this.httpServer?.close();
+                this.httpServer = undefined;
             })
         );
     }
 
     protected async run(options: WebSocketServerOptions): Promise<void> {
+        this.resetListening();
         const resolvedOptions = await this.resolveOptions(options);
-        this.server = new Server({ server: resolvedOptions.server, path: resolvedOptions.path });
+        if (!this.running) {
+            // Shut down while the options were being resolved, so release the socket they already bound.
+            resolvedOptions.server.close();
+            return;
+        }
+        this.httpServer = resolvedOptions.server;
+        this.server = new WebSocketServer({ server: resolvedOptions.server, path: resolvedOptions.path });
         const endpoint = `ws://${resolvedOptions.host}:${resolvedOptions.port}:${resolvedOptions.path}`;
         this.logger.info(`The GLSP Websocket launcher is ready to accept new client requests on endpoint '${endpoint}'`);
         console.log(this.startupCompleteMessage.concat(resolvedOptions.port.toString()));
 
-        this.server.on('connection', ws => this.acceptConnection(ws));
+        this.observeListening(resolvedOptions.server);
+        this.server.on('connection', (ws, request) => this.acceptConnection(ws, request));
 
+        const server = this.server;
         return new Promise((resolve, reject) => {
-            this.server.on('close', () => resolve(undefined));
-            this.server.on('error', error => reject(error));
+            server.on('close', () => resolve(undefined));
+            server.on('error', error => reject(error));
         });
+    }
+
+    /** Settles {@link listening} from the HTTP server, which may already be bound by the time we get here. */
+    protected observeListening(server: http.Server): void {
+        if (server.listening) {
+            this.settleListening(server);
+            return;
+        }
+        server.on('listening', () => this.settleListening(server));
+        server.on('error', error => this.handleError(error));
     }
 
     /**
      * Takes up a web socket the server accepted. Observers are notified before the socket is read from.
      *
-     * @param socket The accepted web socket.
+     * @param socket  The accepted web socket.
+     * @param request The upgrade request the socket was negotiated with.
      */
-    protected acceptConnection(socket: WebSocket): void {
-        this.onConnectionEmitter.fire(socket);
+    protected acceptConnection(socket: WebSocket, request: http.IncomingMessage): void {
+        this.onConnectionEmitter.fire({ socket, request });
         this.createServerInstance(this.createConnection(socket));
     }
 

--- a/packages/server/src/node/test/port-util.ts
+++ b/packages/server/src/node/test/port-util.ts
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import * as net from 'net';
+import { expect } from 'vitest';
+
+export function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolves whether a TCP connection to the given port is currently accepted.
+ *
+ * The outcome is routed through the returned promise rather than asserted inside the socket event
+ * callbacks on purpose: an assertion thrown from a detached socket listener escapes the test's
+ * promise chain and surfaces as a Vitest "unhandled error" that fails the run *without* turning any
+ * individual test red. Resolving/rejecting keeps every outcome attributable to the calling test.
+ */
+export function isReachable(port: number): Promise<boolean> {
+    return new Promise(resolve => {
+        const socket = new net.Socket();
+        socket.setTimeout(1000);
+        const finish = (reachable: boolean): void => {
+            socket.destroy();
+            resolve(reachable);
+        };
+        socket
+            .on('connect', () => finish(true))
+            .on('error', () => finish(false))
+            .on('timeout', () => finish(false))
+            .connect(port);
+    });
+}
+
+/** Polls until the port reaches the expected reachability, or fails the test once the deadline elapses. */
+export async function waitForReachable(port: number, expected: boolean, deadlineMs = 5000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < deadlineMs) {
+        if ((await isReachable(port)) === expected) {
+            return;
+        }
+
+        await delay(50);
+    }
+    expect.fail(`Port ${port} did not become ${expected ? 'reachable' : 'unreachable'} within ${deadlineMs}ms`);
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "lib",
     "composite": true
   },
-  "exclude": ["**/*.spec.ts", "src/common/test/mock-util.ts"],
+  "exclude": ["**/*.spec.ts", "src/common/test/mock-util.ts", "src/node/test/port-util.ts"],
   "include": ["src"],
   "references": [
     {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

Launching with port 0 lets the operating system pick a free port, but the launcher kept both that port and the server socket to itself. An embedder that needs to hand the port to a client, or to observe accepted connections, had to parse the startup message off stdout or reach for the protected server field.

- add `listening`, a deferred that resolves with the bound address once the socket is up and rejects if it never gets there
- add `port`, a snapshot of the port currently bound, undefined while not listening
- add an `onConnection` event to the socket and websocket launchers, fired for every accepted socket before the JSON-RPC connection is built on it, so a listener can still see the client handshake
- arm a fresh deferred per run, so a settled promise is never handed to the next launch
- split the socket event handling into onListening, onError, failToListen and acceptConnection so adopters can override one step
- report a socket error through the logger before shutting down, it was previously discarded

Exposing this surfaced that a restarted launcher could not be shut down: the launchers registered their cleanup in the constructor, but DisposableCollection.dispose pops every entry it holds, so the first shutdown emptied the collection and the second reported success while the server socket stayed bound and the client sessions stayed alive.

- add a registerDisposables hook to GLSPServerLauncher, called once per launch, and move the netServer, websocket server and server-instance cleanup into it
- disposing a launcher that was never started is now a no-op instead of closing an undefined server

Fixes eclipse-glsp/glsp#1729

#### How to test

Everything is working as before but now you can add listeners and get the port returned properly.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
