### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Eclipse GLSP Server Changelog
 
-## v2.8.0 - active
+## [v2.8.0 - 28/08/2026](https://github.com/eclipse-glsp/glsp-server-node/releases/tag/v2.8.0)
 
 ### Changes
 

--- a/examples/workflow-server-bundled-web/package.json
+++ b/examples/workflow-server-bundled-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server-bundled-web",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "GLSP web server for the workflow example (bundled)",
   "keywords": [
     "eclipse",

--- a/examples/workflow-server-bundled/package.json
+++ b/examples/workflow-server-bundled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server-bundled",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "GLSP node server for the workflow example (bundled)",
   "keywords": [
     "eclipse",

--- a/examples/workflow-server-mcp-demo/package.json
+++ b/examples/workflow-server-mcp-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server-mcp-demo",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": true,
   "description": "Browser demo that drives the @eclipse-glsp/server-mcp portable Fetch handler against the workflow web server bundle.",
   "homepage": "https://www.eclipse.org/glsp/",

--- a/examples/workflow-server/package.json
+++ b/examples/workflow-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp-examples/workflow-server",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "GLSP node server for the workflow example",
   "keywords": [
     "eclipse",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parent",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "build": "pnpm compile && pnpm bundle",
@@ -30,7 +30,7 @@
     "upgrade:next": "glsp updateNext"
   },
   "devDependencies": {
-    "@eclipse-glsp/dev": "next",
+    "@eclipse-glsp/dev": "2.8.0",
     "@types/node": "22.x",
     "typescript": "^5.9.2"
   },

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/graph",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "The typescript implementation of the GLSP graphical model (GModel)",
   "keywords": [
     "eclipse",
@@ -48,7 +48,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@eclipse-glsp/protocol": "next"
+    "@eclipse-glsp/protocol": "2.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/layout-elk/package.json
+++ b/packages/layout-elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/layout-elk",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "Integration of ELK graph layout algorithms in GLSP Node Server",
   "keywords": [
     "eclipse",

--- a/packages/server-mcp/package.json
+++ b/packages/server-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/server-mcp",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "Model Context Protocol (MCP) server for the GLSP TypeScript server — runs on Node, browser, and Fetch-API runtimes",
   "keywords": [
     "eclipse",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/server",
-  "version": "2.8.0-next",
+  "version": "2.8.0",
   "description": "A js server framework for Eclipse GLSP",
   "keywords": [
     "eclipse",
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@eclipse-glsp/graph": "workspace:*",
-    "@eclipse-glsp/protocol": "next",
+    "@eclipse-glsp/protocol": "2.8.0",
     "commander": "^14.0.0",
     "fast-json-patch": "^3.1.0",
     "vscode-jsonrpc": "8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     devDependencies:
       '@eclipse-glsp/dev':
-        specifier: next
-        version: 2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
+        specifier: 2.8.0
+        version: 2.8.0(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
       '@types/node':
         specifier: 22.x
         version: 22.19.21
@@ -65,8 +65,8 @@ importers:
   packages/graph:
     dependencies:
       '@eclipse-glsp/protocol':
-        specifier: next
-        version: 2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
 
   packages/layout-elk:
     dependencies:
@@ -89,8 +89,8 @@ importers:
         specifier: workspace:*
         version: link:../graph
       '@eclipse-glsp/protocol':
-        specifier: next
-        version: 2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
+        specifier: 2.8.0
+        version: 2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       commander:
         specifier: ^14.0.0
         version: 14.0.3
@@ -168,21 +168,21 @@ packages:
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
-  '@eclipse-glsp/cli@2.8.0-next.19':
-    resolution: {integrity: sha512-t+PEnSqOjFXznmAexX7Ekc+jLUIqPlIkUnm1laWi/D9mFHo67KRQ7563qmrTn4Wi0NAsdWeXToFBxFxG6/PfaQ==}
+  '@eclipse-glsp/cli@2.8.0':
+    resolution: {integrity: sha512-ILZKIk3PAxD8sOfgAFr8Qnvyi8SoRs2F/UVoqWGHyhwMqpAdexn/s2VRcMV41h9FC/b/AZ+zc6/BbFTa0222Ew==}
     hasBin: true
 
-  '@eclipse-glsp/config-test@2.8.0-next.19':
-    resolution: {integrity: sha512-kLTnX6MGyKvI9u6TxZek3AQaUcdI/TMuhDBwB0+zGma3lwuGSvXqmqkYDdXrGN5ntuYoq7sfZBuCy+67LO7SXQ==}
+  '@eclipse-glsp/config-test@2.8.0':
+    resolution: {integrity: sha512-r8WGm12zJd7wmIWoMz5+akFmqC+ZucA6l0z8+gX38i/rwZvz2GVeX4LFkOa/eWodkLVVJvjLWjjHcwpOvCvbIA==}
 
-  '@eclipse-glsp/config@2.8.0-next.19':
-    resolution: {integrity: sha512-Jxb3Zq9pw1waIbBINTEy9+7clcB939bOW+Lo56GB38LBd4HkQX82/Gh0EZN7PZhMP/mCfo4J6XGOK0m7q7qbpg==}
+  '@eclipse-glsp/config@2.8.0':
+    resolution: {integrity: sha512-RL/V9NMsjQ2bX9+d4Sbl1fxf7h+eLH8T8mMnjzd5MqvZdJYyUP7n+Yt5vyXenPRuXMpu4jTX9h3HL+u4mziY8g==}
 
-  '@eclipse-glsp/dev@2.8.0-next.19':
-    resolution: {integrity: sha512-Kairzb+bgxSVuBcVPBLxWNbJevMm3nYqbTY1WaY8RXjDCRSW03U50et2AgC2L/F8I1gmJGZLfMF4BhxJzehOIg==}
+  '@eclipse-glsp/dev@2.8.0':
+    resolution: {integrity: sha512-bueBgpXygZQoYdB5lbCd/YpQGrWVUWTea+FK5Ff5cNNFrSEK/dENXPMIz5p9hjxqaQIVG00WLKs3VE6EUTu9WQ==}
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.19':
-    resolution: {integrity: sha512-QlXER0UYOaYT7WpzYpuHbLgjaeKTTjd0USddgvvuWneIwvsRRjaXk9QI0RKeCIKvJHjpzPOFsmW8RTjzp/EMhw==}
+  '@eclipse-glsp/eslint-config@2.8.0':
+    resolution: {integrity: sha512-3hJbDif0O028+59TMXbkv6lzeIxuYZiSsUwmYSbik3NUK+vvp+ipP10mj8m/glISiksAZXa6HRIuOvxaBm2ZYA==}
     peerDependencies:
       '@eslint/js': ^10.0.1
       '@stylistic/eslint-plugin': ^5.10.0
@@ -195,11 +195,11 @@ packages:
       globals: ^17.6.0
       typescript-eslint: ^8.0.0
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.19':
-    resolution: {integrity: sha512-pBLY7CQYHl0pAwSTiNPr4j182sSi0LH9ZwL+Ka0EhvXMMxUfvPMaEmKFi5nXuxVigeOFpRcTaRyuJU0LH15AqA==}
+  '@eclipse-glsp/prettier-config@2.8.0':
+    resolution: {integrity: sha512-Or/vVcsHgN/+q12hcwwRpXragXv43g7kvXlb7HLigltDrlf5W9Mfg3umhUFpC7PTYsdHM7FVi9cwp51ggDBDWQ==}
 
-  '@eclipse-glsp/protocol@2.8.0-next.13':
-    resolution: {integrity: sha512-hS9APz4RFmlFmCaucnHRbWgbQSfgbNBYQGPNQYy8esVzHwB1MQ8T3NBcnWmHBU+smrXronHYtZcAfOtLIw0dlA==}
+  '@eclipse-glsp/protocol@2.8.0':
+    resolution: {integrity: sha512-Dd9sVtX1kRkvWnGeyF9pC2DrHUDYaDgm0TukuRIaw4SvlKeKK2w48c2hmpRkKpsIKbWw8lk8R53FDKTqE52jnQ==}
     peerDependencies:
       inversify: ^6.1.3
       reflect-metadata: ^0.2.2
@@ -209,13 +209,13 @@ packages:
       reflect-metadata:
         optional: true
 
-  '@eclipse-glsp/ts-config@2.8.0-next.19':
-    resolution: {integrity: sha512-zH7UW1+upPxvGljLMTuOP+S7yfXtxyvDcXnkc+iPWtzZORzcLm7IZRYfzoC6EKx45cllyasiLwV5ebhk6a/QOw==}
+  '@eclipse-glsp/ts-config@2.8.0':
+    resolution: {integrity: sha512-H7Eb5bfE7IhzEvOi7t80y07dIMmC62jTAF1baWvP8T4HRHOuQH/pOnmlN2/e0tQe1CYpykGZMMO0YFO8+xuDSA==}
     peerDependencies:
       typescript: '>=5.5'
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.19':
-    resolution: {integrity: sha512-Kq2VLBCTbp2keeNnNK6Io06iTSepzsQ/Ql3FCrXsEMyDziYYKsPsmZ1wbMbCWFoziQokWzTf4pkTcwVCymPWCQ==}
+  '@eclipse-glsp/vitest-config@2.8.0':
+    resolution: {integrity: sha512-8+ZZRbwNBCe9283F9TEjNpWdGJdCQGUfuUtMcgGCBbiAY3h+/0Y147KKAPkcBe3vd17po8okFmOqFdqbetqnkw==}
     peerDependencies:
       '@vitest/coverage-v8': '>=4.0.0'
       vitest: '>=4.0.0'
@@ -2005,11 +2005,11 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@eclipse-glsp/cli@2.8.0-next.19': {}
+  '@eclipse-glsp/cli@2.8.0': {}
 
-  '@eclipse-glsp/config-test@2.8.0-next.19(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
+  '@eclipse-glsp/config-test@2.8.0(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
     dependencies:
-      '@eclipse-glsp/vitest-config': 2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
+      '@eclipse-glsp/vitest-config': 2.8.0(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
     transitivePeerDependencies:
@@ -2027,11 +2027,11 @@ snapshots:
       - msw
       - vite
 
-  '@eclipse-glsp/config@2.8.0-next.19(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)':
+  '@eclipse-glsp/config@2.8.0(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@eclipse-glsp/eslint-config': 2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))
-      '@eclipse-glsp/prettier-config': 2.8.0-next.19(prettier@3.8.4)
-      '@eclipse-glsp/ts-config': 2.8.0-next.19(typescript@5.9.3)
+      '@eclipse-glsp/eslint-config': 2.8.0(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))
+      '@eclipse-glsp/prettier-config': 2.8.0(prettier@3.8.4)
+      '@eclipse-glsp/ts-config': 2.8.0(typescript@5.9.3)
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
       '@tony.ganchev/eslint-plugin-header': 3.4.4(eslint@10.5.0)
@@ -2052,11 +2052,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@eclipse-glsp/dev@2.8.0-next.19(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
+  '@eclipse-glsp/dev@2.8.0(@types/node@22.19.21)(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))':
     dependencies:
-      '@eclipse-glsp/cli': 2.8.0-next.19
-      '@eclipse-glsp/config': 2.8.0-next.19(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
-      '@eclipse-glsp/config-test': 2.8.0-next.19(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
+      '@eclipse-glsp/cli': 2.8.0
+      '@eclipse-glsp/config': 2.8.0(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(typescript@5.9.3)
+      '@eclipse-glsp/config-test': 2.8.0(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@opentelemetry/api'
@@ -2078,7 +2078,7 @@ snapshots:
       - typescript
       - vite
 
-  '@eclipse-glsp/eslint-config@2.8.0-next.19(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))':
+  '@eclipse-glsp/eslint-config@2.8.0(@eslint/js@10.0.1(eslint@10.5.0))(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@tony.ganchev/eslint-plugin-header@3.4.4(eslint@10.5.0))(eslint-config-prettier@10.1.8(eslint@10.5.0))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint@10.5.0))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0))(eslint-plugin-no-null@1.0.2(eslint@10.5.0))(eslint@10.5.0)(globals@17.6.0)(typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.5.0)
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
@@ -2091,13 +2091,13 @@ snapshots:
       globals: 17.6.0
       typescript-eslint: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
 
-  '@eclipse-glsp/prettier-config@2.8.0-next.19(prettier@3.8.4)':
+  '@eclipse-glsp/prettier-config@2.8.0(prettier@3.8.4)':
     dependencies:
       prettier-plugin-packagejson: 3.0.2(prettier@3.8.4)
     transitivePeerDependencies:
       - prettier
 
-  '@eclipse-glsp/protocol@2.8.0-next.13(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
+  '@eclipse-glsp/protocol@2.8.0(inversify@6.2.2(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)':
     dependencies:
       sprotty-protocol: 1.4.0
       uuid: 14.0.0
@@ -2106,11 +2106,11 @@ snapshots:
       inversify: 6.2.2(reflect-metadata@0.2.2)
       reflect-metadata: 0.2.2
 
-  '@eclipse-glsp/ts-config@2.8.0-next.19(typescript@5.9.3)':
+  '@eclipse-glsp/ts-config@2.8.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@eclipse-glsp/vitest-config@2.8.0-next.19(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
+  '@eclipse-glsp/vitest-config@2.8.0(@vitest/coverage-v8@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1))


### PR DESCRIPTION
Prepare release v2.8.0

## Changes

- [deps] Switch bundling from webpack to esbuild [#142](https://github.com/eclipse-glsp/glsp-server-node/pull/142)
- [deps] Migrate the build from yarn and lerna to pnpm workspaces [#144](https://github.com/eclipse-glsp/glsp-server-node/pull/144)
- [launch] Expose the address a launcher bound to via `listening` and `port` on `JsonRpcGLSPServerLauncher`, so an embedder no longer has to parse the startup message to learn an OS-assigned port [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
- [launch] Add an `onConnection` event to `SocketServerLauncher` and `WebSocketServerLauncher`, so an embedder can observe accepted connections without reaching for the protected server field [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
    - the web socket event carries the upgrade request next to the socket, which is the only place its headers and query are still available
- [launch] Release the server socket again when a restarted launcher is shut down [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
    - `WebSocketServerLauncher` now also closes the HTTP server it mounts on, which `ws` leaves listening because it did not create it
- [mcp] Return results that satisfy the declared output schema, so a `create-edges` dry run returns its verdicts instead of an output-validation error [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
- [mcp] Stop reporting success for work that was not done [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
    - `save-model` writes to an explicit `fileUri` even when the command stack is clean, instead of skipping a save-as
    - `undo` and `redo` report how many commands they applied, not how many were requested
    - `modify-nodes` and `modify-edges` report an error for entries that request no change, instead of counting them as modified
- [mcp] Reject unknown element ids in `validate-diagram` and `set-view`, which previously dropped them and returned an empty, clean-looking result [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
- [mcp] Keep tools out of the MCP catalog when no diagram type supports them, so `layout` is no longer advertised without a bound `LayoutEngine` [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
    - the new `isSupportedByDiagramType()` hook on the diagram tool and resource bases covers statically bound dependencies; `canRegister()` keeps gating capabilities of the connected GLSP client
- [mcp] Align tool schemas and descriptions with what the tools actually accept and apply [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
    - `set-selection` accepts the documented empty-array form for clearing the selection, and `undo` / `redo` require integer counts
    - `modify-nodes` positions are parent-relative and `create-nodes` positions absolute, matching the dispatched operations
    - the `create-*` tools echo the created element when its type differs from the requested `elementTypeId`, instead of reporting a creation failure

### Potentially Breaking Changes

- [elk] Replace the no-op ELK factory in web worker contexts with a working in-process implementation [#141](https://github.com/eclipse-glsp/glsp-server-node/pull/141)
    - `elkLayoutModule` was effectively a no-op in the browser and now actually performs layout, so adopters that relied on that behavior have to adapt accordingly
- [layout] Keep applying computed bounds when an individual entry cannot be applied [#149](https://github.com/eclipse-glsp/glsp-server-node/pull/149)
    - `applyRoute` now returns `GEdge | undefined` instead of `GEdge`
    - `applyElementAndBounds`, `applyAlignment` and `applyRoute` no longer throw for an element the index cannot resolve, they report it as not applied. `applyRoutingPoints` stays strict.
- [launch] Launchers register what `shutdown` has to release in the new `GLSPServerLauncher.registerDisposables` hook, called once per launch, rather than in their constructor [#150](https://github.com/eclipse-glsp/glsp-server-node/pull/150)
    - A custom launcher that pushes into `toDispose` from its constructor keeps compiling but loses that cleanup after the first `shutdown`, because `dispose` empties the collection. Move those registrations into an override of `registerDisposables`.
- [mcp] The MCP tool handler bases take an optional output type parameter, e.g. `AbstractMcpDiagramToolHandler<I, O>`, bound to the handler's declared `outputSchema` [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
    - The parameter defaults, so a handler without an `outputSchema` is unaffected. A subclass that passes `success()` a payload not matching the overridden handler's output schema now fails to compile, instead of producing an error result at call time.
- [mcp] `modify-nodes` rejects `position` / `size` for elements that are not a `GNode`, which core's bounds handler silently ignored while the tool reported success [#152](https://github.com/eclipse-glsp/glsp-server-node/pull/152)
    - Adopters who bind a bounds handler covering more element kinds override the guard in `ModifyNodesMcpToolHandler`.

**Full Changelog**: https://github.com/eclipse-glsp/glsp-server-node/compare/v2.7.0...v2.8.0


Note: This pull request was created automatically. After merging, the automated publishing process will be started.
